### PR TITLE
Make non-library ratings work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.pyo
 .DS*
 .pylint_rc
+/.project
+/.pydevproject

--- a/rating.py
+++ b/rating.py
@@ -161,7 +161,7 @@ def rateOnTrakt(rating, media_type, media, unrate=False):
 		s = utils.getFormattedItemName(media_type, media)
 		if 'status' in data and data['status'] == "success":
 
-			if tagging.isTaggingEnabled() and tagging.isRatingsEnabled():
+			if 'xbmc_id' in media and tagging.isTaggingEnabled() and tagging.isRatingsEnabled():
 				if utils.isMovie(media_type) or utils.isShow(media_type):
 
 					id = media['xbmc_id']

--- a/service.py
+++ b/service.py
@@ -200,7 +200,7 @@ class traktService:
 			
 		if 'dbid' in data:
 			utilities.Debug("Getting data for manual %s of library '%s' with ID of '%s'" % (action, media_type, data['dbid']))
-		elif 'remoteitd' in data:
+		elif 'remoteid' in data:
 			if 'season' in data:
 				utilities.Debug("Getting data for manual %s of non-library '%s' S%02dE%02d, with ID of '%s'." % (action, media_type, data['season'], data['episode'], data['remoteid']))
 			else:
@@ -214,7 +214,7 @@ class traktService:
 			summaryInfo = globals.traktapi.getMovieSummary(data['imdbnumber'])
 		
 		if not summaryInfo is None:
-			if utilities.isMovie(media_type) or utilities.isShow(media_type):
+			if 'dbid' in data and (utilities.isMovie(media_type) or utilities.isShow(media_type)):
 				summaryInfo['xbmc_id'] = data['dbid']
 
 			if action == 'rate':


### PR DESCRIPTION
This PR makes calling the "rate" action work for non-library items. I tested calling the "rate" action with imdb id as "remoteid" on movies, tv shows and episodes and they all work as expected. 
