### PR TITLE
Use decode to remove unicode errors

### DIFF
--- a/utilities.py
+++ b/utilities.py
@@ -269,7 +269,7 @@ def findInList(list, returnIndex=False, returnCopy=False, case_sensitive=True, *
 					i = i + 1
 			else:
 				# forcing the compare to be done at the string level
-				if str(key_val) == str(kwargs[key]):
+				if key_val.decode('utf-8') == kwargs[key].decode('utf-8'):
 					i = i + 1
 		if i == len(kwargs):
 			if returnIndex:


### PR DESCRIPTION
Was getting a decode error on sync:
                                              File "/storage/.kodi/addons/script.trakt/utilities.py", line 272, in findInList
                                                if unicode(key_val) == unicode(kwargs[key]):
                                            UnicodeEncodeError: 'ascii' codec can't encode character u'\xb3' in position 5: ordinal not in range(128)

This fixes that problem and sync was able to complete on my system.