### PR TITLE
pep8 cleanup

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.trakt" name="Trakt" version="3.0.1~beta1" provider-name="Trakt.tv">
+<addon id="script.trakt" name="Trakt" version="3.0.1~beta2" provider-name="Trakt.tv">
 	<requires>
 		<import addon="xbmc.python" version="2.1.0"/>
 		<import addon="script.module.simplejson" version="3.3.0"/>

--- a/default.py
+++ b/default.py
@@ -15,9 +15,9 @@ logger = logging.getLogger(__name__)
 logger.debug("Loading '%s' version '%s'" % (__addonid__, __addonversion__))
 
 try:
-	traktService().run()
+    traktService().run()
 except Exception as ex:
-	message = createError(ex)
-	logger.fatal(message)
+    message = createError(ex)
+    logger.fatal(message)
 
 logger.debug("'%s' shutting down." % __addonid__)

--- a/kodilogging.py
+++ b/kodilogging.py
@@ -25,35 +25,32 @@ import xbmcaddon
 
 class KodiLogHandler(logging.StreamHandler):
 
-	def __init__(self):
-		logging.StreamHandler.__init__(self)
-		addon_id = xbmcaddon.Addon().getAddonInfo('id')
-		prefix = b"[%s] " % addon_id
-		formatter = logging.Formatter(prefix + b'%(name)s: %(message)s')
-		self.setFormatter(formatter)
+    def __init__(self):
+        logging.StreamHandler.__init__(self)
+        addon_id = xbmcaddon.Addon().getAddonInfo('id')
+        prefix = b"[%s] " % addon_id
+        formatter = logging.Formatter(prefix + b'%(name)s: %(message)s')
+        self.setFormatter(formatter)
 
-	def emit(self, record):
-		levels = {
-			logging.CRITICAL: xbmc.LOGFATAL,
-			logging.ERROR: xbmc.LOGERROR,
-			logging.WARNING: xbmc.LOGWARNING,
-			logging.INFO: xbmc.LOGINFO,
-			logging.DEBUG: xbmc.LOGDEBUG,
-			logging.NOTSET: xbmc.LOGNONE,
-		}
-		if getSettingAsBool('debug'):
-			try:
-				xbmc.log(self.format(record), levels[record.levelno])
-			except UnicodeEncodeError:
-				xbmc.log(self.format(record).encode('utf-8', 'ignore'), levels[record.levelno])
+    def emit(self, record):
+        levels = {
+            logging.CRITICAL: xbmc.LOGFATAL,
+            logging.ERROR: xbmc.LOGERROR,
+            logging.WARNING: xbmc.LOGWARNING,
+            logging.INFO: xbmc.LOGINFO,
+            logging.DEBUG: xbmc.LOGDEBUG,
+            logging.NOTSET: xbmc.LOGNONE,
+        }
+        if getSettingAsBool('debug'):
+            try:
+                xbmc.log(self.format(record), levels[record.levelno])
+            except UnicodeEncodeError:
+                xbmc.log(self.format(record).encode('utf-8', 'ignore'), levels[record.levelno])
 
-
-
-	def flush(self):
-		pass
-
+    def flush(self):
+        pass
 
 def config():
-	logger = logging.getLogger()
-	logger.addHandler(KodiLogHandler())
-	logger.setLevel(logging.DEBUG)
+    logger = logging.getLogger()
+    logger.addHandler(KodiLogHandler())
+    logger.setLevel(logging.DEBUG)

--- a/rating.py
+++ b/rating.py
@@ -13,201 +13,201 @@ logger = logging.getLogger(__name__)
 __addon__ = xbmcaddon.Addon("script.trakt")
 
 def ratingCheck(media_type, summary_info, watched_time, total_time, playlist_length):
-	"""Check if a video should be rated and if so launches the rating dialog"""
-	logger.debug("Rating Check called for '%s'" % media_type);
-	if not utils.getSettingAsBool("rate_%s" % media_type):
-		logger.debug("'%s' is configured to not be rated." % media_type)
-		return
-	if summary_info is None or 'user' not in summary_info:
-		logger.debug("Summary information is empty, aborting.")
-		return
-	watched = (watched_time / total_time) * 100
-	if watched >= utils.getSettingAsFloat("rate_min_view_time"):
-		if (playlist_length <= 1) or utils.getSettingAsBool("rate_each_playlist_item"):
-			rateMedia(media_type, summary_info)
-		else:
-			logger.debug("Rate each playlist item is disabled.")
-	else:
-		logger.debug("'%s' does not meet minimum view time for rating (watched: %0.2f%%, minimum: %0.2f%%)" % (media_type, watched, utils.getSettingAsFloat("rate_min_view_time")))
+    """Check if a video should be rated and if so launches the rating dialog"""
+    logger.debug("Rating Check called for '%s'" % media_type)
+    if not utils.getSettingAsBool("rate_%s" % media_type):
+        logger.debug("'%s' is configured to not be rated." % media_type)
+        return
+    if summary_info is None or 'user' not in summary_info:
+        logger.debug("Summary information is empty, aborting.")
+        return
+    watched = (watched_time / total_time) * 100
+    if watched >= utils.getSettingAsFloat("rate_min_view_time"):
+        if (playlist_length <= 1) or utils.getSettingAsBool("rate_each_playlist_item"):
+            rateMedia(media_type, summary_info)
+        else:
+            logger.debug("Rate each playlist item is disabled.")
+    else:
+        logger.debug("'%s' does not meet minimum view time for rating (watched: %0.2f%%, minimum: %0.2f%%)" % (media_type, watched, utils.getSettingAsFloat("rate_min_view_time")))
 
 def rateMedia(media_type, summary_info, unrate=False, rating=None):
-	"""Launches the rating dialog"""
-	if not utils.isValidMediaType(media_type):
-		return
+    """Launches the rating dialog"""
+    if not utils.isValidMediaType(media_type):
+        return
 
-	s = utils.getFormattedItemName(media_type, summary_info)
+    s = utils.getFormattedItemName(media_type, summary_info)
 
-	logger.debug("Summary Info %s" % summary_info)
+    logger.debug("Summary Info %s" % summary_info)
 
-	if unrate:
-		rating = None
+    if unrate:
+        rating = None
 
-		if summary_info['user']['ratings']['rating'] > 0:
-			rating = 0
+        if summary_info['user']['ratings']['rating'] > 0:
+            rating = 0
 
-		if not rating is None:
-			logger.debug("'%s' is being unrated." % s)
-			__rateOnTrakt(rating, media_type, summary_info, unrate=True)
-		else:
-			logger.debug("'%s' has not been rated, so not unrating." % s)
+        if not rating is None:
+            logger.debug("'%s' is being unrated." % s)
+            __rateOnTrakt(rating, media_type, summary_info, unrate=True)
+        else:
+            logger.debug("'%s' has not been rated, so not unrating." % s)
 
-		return
+        return
 
-	rerate = utils.getSettingAsBool('rate_rerate')
-	if rating is not None:
-		if summary_info['user']['ratings']['rating'] == 0:
-			logger.debug("Rating for '%s' is being set to '%d' manually." % (s, rating))
-			__rateOnTrakt(rating, media_type, summary_info)
-		else:
-			if rerate:
-				if not summary_info['user']['ratings']['rating'] == rating:
-					logger.debug("Rating for '%s' is being set to '%d' manually." % (s, rating))
-					__rateOnTrakt(rating, media_type, summary_info)
-				else:
-					utils.notification(utils.getString(32043), s)
-					logger.debug("'%s' already has a rating of '%d'." % (s, rating))
-			else:
-				utils.notification(utils.getString(32041), s)
-				logger.debug("'%s' is already rated." % s)
-		return
+    rerate = utils.getSettingAsBool('rate_rerate')
+    if rating is not None:
+        if summary_info['user']['ratings']['rating'] == 0:
+            logger.debug("Rating for '%s' is being set to '%d' manually." % (s, rating))
+            __rateOnTrakt(rating, media_type, summary_info)
+        else:
+            if rerate:
+                if not summary_info['user']['ratings']['rating'] == rating:
+                    logger.debug("Rating for '%s' is being set to '%d' manually." % (s, rating))
+                    __rateOnTrakt(rating, media_type, summary_info)
+                else:
+                    utils.notification(utils.getString(32043), s)
+                    logger.debug("'%s' already has a rating of '%d'." % (s, rating))
+            else:
+                utils.notification(utils.getString(32041), s)
+                logger.debug("'%s' is already rated." % s)
+        return
 
-	if summary_info['user']['ratings'] and summary_info['user']['ratings']['rating']:
-		if not rerate:
-			logger.debug("'%s' has already been rated." % s)
-			utils.notification(utils.getString(32041), s)
-			return
-		else:
-			logger.debug("'%s' is being re-rated." % s)
-	
-	xbmc.executebuiltin('Dialog.Close(all, true)')
+    if summary_info['user']['ratings'] and summary_info['user']['ratings']['rating']:
+        if not rerate:
+            logger.debug("'%s' has already been rated." % s)
+            utils.notification(utils.getString(32041), s)
+            return
+        else:
+            logger.debug("'%s' is being re-rated." % s)
+    
+    xbmc.executebuiltin('Dialog.Close(all, true)')
 
-	gui = RatingDialog(
-		"RatingDialog.xml",
-		__addon__.getAddonInfo('path'),
-		media_type=media_type,
-		media=summary_info,
-		rerate=rerate
-	)
+    gui = RatingDialog(
+        "RatingDialog.xml",
+        __addon__.getAddonInfo('path'),
+        media_type=media_type,
+        media=summary_info,
+        rerate=rerate
+    )
 
-	gui.doModal()
-	if gui.rating:
-		rating = gui.rating
-		if rerate:
-			rating = gui.rating
-			
-			if summary_info['user']['ratings'] and summary_info['user']['ratings']['rating'] > 0 and rating == summary_info['user']['ratings']['rating']:
-				rating = 0
+    gui.doModal()
+    if gui.rating:
+        rating = gui.rating
+        if rerate:
+            rating = gui.rating
+            
+            if summary_info['user']['ratings'] and summary_info['user']['ratings']['rating'] > 0 and rating == summary_info['user']['ratings']['rating']:
+                rating = 0
 
-		if rating == 0 or rating == "unrate":
-			__rateOnTrakt(rating, gui.media_type, gui.media, unrate=True)
-		else:
-			__rateOnTrakt(rating, gui.media_type, gui.media)
-	else:
-		logger.debug("Rating dialog was closed with no rating.")
+        if rating == 0 or rating == "unrate":
+            __rateOnTrakt(rating, gui.media_type, gui.media, unrate=True)
+        else:
+            __rateOnTrakt(rating, gui.media_type, gui.media)
+    else:
+        logger.debug("Rating dialog was closed with no rating.")
 
-	del gui
+    del gui
 
 def __rateOnTrakt(rating, media_type, media, unrate=False):
-	logger.debug("Sending rating (%s) to Trakt.tv" % rating)
+    logger.debug("Sending rating (%s) to Trakt.tv" % rating)
 
-	params = media
-	if utils.isMovie(media_type):
-		key = 'movies'
-		params['rating'] = rating
-	elif utils.isShow(media_type):
-		key = 'shows'
-		params['rating'] = rating
-	elif utils.isSeason(media_type):
-		key = 'shows'
-		params['seasons'] = [{'rating': rating, 'number': media['season']}]
-	elif utils.isEpisode(media_type):
-		key = 'episodes'
-		params['rating'] = rating
-	else:
-		return
-	root = {key: [params]}
+    params = media
+    if utils.isMovie(media_type):
+        key = 'movies'
+        params['rating'] = rating
+    elif utils.isShow(media_type):
+        key = 'shows'
+        params['rating'] = rating
+    elif utils.isSeason(media_type):
+        key = 'shows'
+        params['seasons'] = [{'rating': rating, 'number': media['season']}]
+    elif utils.isEpisode(media_type):
+        key = 'episodes'
+        params['rating'] = rating
+    else:
+        return
+    root = {key: [params]}
 
-	if not unrate:
-		data = globals.traktapi.addRating(root)
-	else:
-		data = globals.traktapi.removeRating(root)
+    if not unrate:
+        data = globals.traktapi.addRating(root)
+    else:
+        data = globals.traktapi.removeRating(root)
 
-	if data:
-		s = utils.getFormattedItemName(media_type, media)
-		if 'not_found' in data and not data['not_found']['movies'] and not data['not_found']['episodes'] and not data['not_found']['shows']:
+    if data:
+        s = utils.getFormattedItemName(media_type, media)
+        if 'not_found' in data and not data['not_found']['movies'] and not data['not_found']['episodes'] and not data['not_found']['shows']:
 
-			if not unrate:
-				utils.notification(utils.getString(32040), s)
-			else:
-				utils.notification(utils.getString(32042), s)
-		else:
-			utils.notification(utils.getString(32044), s)
+            if not unrate:
+                utils.notification(utils.getString(32040), s)
+            else:
+                utils.notification(utils.getString(32042), s)
+        else:
+            utils.notification(utils.getString(32044), s)
 
 class RatingDialog(xbmcgui.WindowXMLDialog):
-	buttons = {
-		11030:	1,
-		11031:	2,
-		11032:	3,
-		11033:	4,
-		11034:	5,
-		11035:	6,
-		11036:	7,
-		11037:	8,
-		11038:	9,
-		11039:	10
-	}
+    buttons = {
+        11030: 1,
+        11031: 2,
+        11032: 3,
+        11033: 4,
+        11034: 5,
+        11035: 6,
+        11036: 7,
+        11037: 8,
+        11038: 9,
+        11039: 10
+    }
 
-	focus_labels = {
-		11030: 32028,
-		11031: 32029,
-		11032: 32030,
-		11033: 32031,
-		11034: 32032,
-		11035: 32033,
-		11036: 32034,
-		11037: 32035,
-		11038: 32036,
-		11039: 32027
-	}
+    focus_labels = {
+        11030: 32028,
+        11031: 32029,
+        11032: 32030,
+        11033: 32031,
+        11034: 32032,
+        11035: 32033,
+        11036: 32034,
+        11037: 32035,
+        11038: 32036,
+        11039: 32027
+    }
 
-	def __init__(self, xmlFile, resourcePath, forceFallback=False, media_type=None, media=None, rerate=False):
-		self.media_type = media_type
-		self.media = media
-		self.rating = None
-		self.rerate = rerate
-		self.default_rating = utils.getSettingAsInt('rating_default')
+    def __init__(self, xmlFile, resourcePath, forceFallback=False, media_type=None, media=None, rerate=False):
+        self.media_type = media_type
+        self.media = media
+        self.rating = None
+        self.rerate = rerate
+        self.default_rating = utils.getSettingAsInt('rating_default')
 
-	def onInit(self):
-		s = utils.getFormattedItemName(self.media_type, self.media)
-		self.getControl(10012).setLabel(s)
+    def onInit(self):
+        s = utils.getFormattedItemName(self.media_type, self.media)
+        self.getControl(10012).setLabel(s)
 
-		rateID = 11029 + self.default_rating
-		if self.rerate and self.media['user']['ratings'] and int(self.media['user']['ratings']['rating']) > 0:
-			rateID = 11029 + int(self.media['user']['ratings']['rating'])
-		self.setFocus(self.getControl(rateID))
+        rateID = 11029 + self.default_rating
+        if self.rerate and self.media['user']['ratings'] and int(self.media['user']['ratings']['rating']) > 0:
+            rateID = 11029 + int(self.media['user']['ratings']['rating'])
+        self.setFocus(self.getControl(rateID))
 
-	def onClick(self, controlID):
-		if controlID in self.buttons:
-			self.rating = self.buttons[controlID]
-			self.close()
+    def onClick(self, controlID):
+        if controlID in self.buttons:
+            self.rating = self.buttons[controlID]
+            self.close()
 
-	def onFocus(self, controlID):
-		if controlID in self.focus_labels:
-			s = utils.getString(self.focus_labels[controlID])
+    def onFocus(self, controlID):
+        if controlID in self.focus_labels:
+            s = utils.getString(self.focus_labels[controlID])
 
-			if self.rerate:
-				if self.media['user']['ratings'] and self.media['user']['ratings']['rating'] == self.buttons[controlID]:
-					if utils.isMovie(self.media_type):
-						s = utils.getString(32037)
-					elif utils.isShow(self.media_type):
-						s = utils.getString(32038)
-					elif utils.isEpisode(self.media_type):
-						s = utils.getString(32039)
-					elif utils.isSeason(self.media_type):
-						s = utils.getString(32132)
-					else:
-						pass
+            if self.rerate:
+                if self.media['user']['ratings'] and self.media['user']['ratings']['rating'] == self.buttons[controlID]:
+                    if utils.isMovie(self.media_type):
+                        s = utils.getString(32037)
+                    elif utils.isShow(self.media_type):
+                        s = utils.getString(32038)
+                    elif utils.isEpisode(self.media_type):
+                        s = utils.getString(32039)
+                    elif utils.isSeason(self.media_type):
+                        s = utils.getString(32132)
+                    else:
+                        pass
 
-			self.getControl(10013).setLabel(s)
-		else:
-			self.getControl(10013).setLabel('')
+            self.getControl(10013).setLabel(s)
+        else:
+            self.getControl(10013).setLabel('')

--- a/script.py
+++ b/script.py
@@ -9,254 +9,254 @@ from traktContextMenu import traktContextMenu
 logger = logging.getLogger(__name__)
 
 def __getMediaType():
-	
-	if xbmc.getCondVisibility('Container.Content(tvshows)'):
-		return "show"
-	elif xbmc.getCondVisibility('Container.Content(seasons)'):
-		return "season"
-	elif xbmc.getCondVisibility('Container.Content(episodes)'):
-		return "episode"
-	elif xbmc.getCondVisibility('Container.Content(movies)'):
-		return "movie"
-	else:
-		return None
+    
+    if xbmc.getCondVisibility('Container.Content(tvshows)'):
+        return "show"
+    elif xbmc.getCondVisibility('Container.Content(seasons)'):
+        return "season"
+    elif xbmc.getCondVisibility('Container.Content(episodes)'):
+        return "episode"
+    elif xbmc.getCondVisibility('Container.Content(movies)'):
+        return "movie"
+    else:
+        return None
 
 def __getArguments():
-	data = None
-	default_actions = {0: "sync"}
-	if len(sys.argv) == 1:
-		data = {'action': default_actions[0]}
-	else:
-		data = {}
-		for item in sys.argv:
-			values = item.split("=")
-			if len(values) == 2:
-				data[values[0].lower()] = values[1]
-		data['action'] = data['action'].lower()
+    data = None
+    default_actions = {0: "sync"}
+    if len(sys.argv) == 1:
+        data = {'action': default_actions[0]}
+    else:
+        data = {}
+        for item in sys.argv:
+            values = item.split("=")
+            if len(values) == 2:
+                data[values[0].lower()] = values[1]
+        data['action'] = data['action'].lower()
 
-	return data
+    return data
 
 def Main():
-	args = __getArguments()
-	data = {}
+    args = __getArguments()
+    data = {}
 
-	if args['action'] == 'contextmenu':
-		buttons = []
-		media_type = __getMediaType()
+    if args['action'] == 'contextmenu':
+        buttons = []
+        media_type = __getMediaType()
 
-		if media_type in ['movie', 'show', 'season', 'episode']:
-			buttons.append("rate")
+        if media_type in ['movie', 'show', 'season', 'episode']:
+            buttons.append("rate")
 
-		if media_type in ['movie', 'show', 'season', 'episode']:
-			buttons.append("togglewatched")
+        if media_type in ['movie', 'show', 'season', 'episode']:
+            buttons.append("togglewatched")
 
-		buttons.append("sync")
+        buttons.append("sync")
 
-		contextMenu = traktContextMenu(media_type=media_type, buttons=buttons)
-		contextMenu.doModal()
-		_action = contextMenu.action
-		del contextMenu
+        contextMenu = traktContextMenu(media_type=media_type, buttons=buttons)
+        contextMenu.doModal()
+        _action = contextMenu.action
+        del contextMenu
 
-		if _action is None:
-			return
+        if _action is None:
+            return
 
-		logger.debug("'%s' selected from trakt.tv action menu" % _action)
-		args['action'] = _action
+        logger.debug("'%s' selected from trakt.tv action menu" % _action)
+        args['action'] = _action
 
-	if args['action'] == 'sync':
-		data = {'action': 'manualSync', 'silent': False}
-		if 'silent' in args:
-			data['silent'] = (args['silent'].lower() == 'true')
-		data['library'] = "all"
-		if 'library' in args and args['library'] in ['episodes', 'movies']:
-			data['library'] = args['library']
+    if args['action'] == 'sync':
+        data = {'action': 'manualSync', 'silent': False}
+        if 'silent' in args:
+            data['silent'] = (args['silent'].lower() == 'true')
+        data['library'] = "all"
+        if 'library' in args and args['library'] in ['episodes', 'movies']:
+            data['library'] = args['library']
 
-	elif args['action'] in ['rate', 'unrate']:
-		#todo fix this
-		data = {'action': args['action']}
-		media_type = None
-		if 'media_type' in args and 'dbid' in args:
-			media_type = args['media_type']
-			try:
-				data['dbid'] = int(args['dbid'])
-			except ValueError:
-				logger.debug("Manual %s triggered for library item, but DBID is invalid." % args['action'])
-				return
-		elif 'media_type' in args and 'remoteid' in args:
-			media_type = args['media_type']
-			data['remoteid'] = args['remoteid']
-			try:
-				data['season'] = int(args['season'])
-				data['episode'] = int(args['episode'])
-			except ValueError:
-				logger.debug("Error parsing season or episode for manual %s" % args['action'])
-				return
-			except KeyError:
-				pass
-		else:
-			media_type = __getMediaType()
-			if not utils.isValidMediaType(media_type):
-				logger.debug("Error, not in video library.")
-				return
-			data['dbid'] = int(xbmc.getInfoLabel('ListItem.DBID'))
+    elif args['action'] in ['rate', 'unrate']:
+        #todo fix this
+        data = {'action': args['action']}
+        media_type = None
+        if 'media_type' in args and 'dbid' in args:
+            media_type = args['media_type']
+            try:
+                data['dbid'] = int(args['dbid'])
+            except ValueError:
+                logger.debug("Manual %s triggered for library item, but DBID is invalid." % args['action'])
+                return
+        elif 'media_type' in args and 'remoteid' in args:
+            media_type = args['media_type']
+            data['remoteid'] = args['remoteid']
+            try:
+                data['season'] = int(args['season'])
+                data['episode'] = int(args['episode'])
+            except ValueError:
+                logger.debug("Error parsing season or episode for manual %s" % args['action'])
+                return
+            except KeyError:
+                pass
+        else:
+            media_type = __getMediaType()
+            if not utils.isValidMediaType(media_type):
+                logger.debug("Error, not in video library.")
+                return
+            data['dbid'] = int(xbmc.getInfoLabel('ListItem.DBID'))
 
-		if media_type is None:
-			logger.debug("Manual %s triggered on an unsupported content container." % args['action'])
-		elif utils.isValidMediaType(media_type):
-			data['media_type'] = media_type
-			if 'dbid' in data:
-				logger.debug("Manual %s of library '%s' with an ID of '%s'." % (args['action'], media_type, data['dbid']))
-				if utils.isMovie(media_type):
-					result = utils.getMovieDetailsFromKodi(data['dbid'], ['imdbnumber', 'title', 'year'])
-					if not result:
-						logger.debug("No data was returned from Kodi, aborting manual %s." % args['action'])
-						return
-					data['imdbnumber'] = result['imdbnumber']
+        if media_type is None:
+            logger.debug("Manual %s triggered on an unsupported content container." % args['action'])
+        elif utils.isValidMediaType(media_type):
+            data['media_type'] = media_type
+            if 'dbid' in data:
+                logger.debug("Manual %s of library '%s' with an ID of '%s'." % (args['action'], media_type, data['dbid']))
+                if utils.isMovie(media_type):
+                    result = utils.getMovieDetailsFromKodi(data['dbid'], ['imdbnumber', 'title', 'year'])
+                    if not result:
+                        logger.debug("No data was returned from Kodi, aborting manual %s." % args['action'])
+                        return
+                    data['imdbnumber'] = result['imdbnumber']
 
-				elif utils.isShow(media_type) or utils.isSeason(media_type):
-					result = utils.getShowDetailsFromKodi(data['dbid'], ['imdbnumber', 'tag'])
-					if not result:
-						logger.debug("No data was returned from Kodi, aborting manual %s." % args['action'])
-						return
-					data['imdbnumber'] = result['imdbnumber']
-					data['tag'] = result['tag']
+                elif utils.isShow(media_type) or utils.isSeason(media_type):
+                    result = utils.getShowDetailsFromKodi(data['dbid'], ['imdbnumber', 'tag'])
+                    if not result:
+                        logger.debug("No data was returned from Kodi, aborting manual %s." % args['action'])
+                        return
+                    data['imdbnumber'] = result['imdbnumber']
+                    data['tag'] = result['tag']
 
-				elif utils.isEpisode(media_type):
-					result = utils.getEpisodeDetailsFromKodi(data['dbid'], ['showtitle', 'season', 'episode', 'tvshowid', 'uniqueid', 'file', 'playcount'])
-					if not result:
-						logger.debug("No data was returned from Kodi, aborting manual %s." % args['action'])
-						return
-					data['imdbnumber'] = result['episodeid']
-					data['season'] = result['season']
-					data['episode'] = result['episode']
-			else:
-				data['imdbnumber'] = data['remoteid']
-				if 'season' in data and 'episode' in data:
-					logger.debug("Manual %s of non-library '%s' S%02dE%02d, with an ID of '%s'." % (args['action'], media_type, data['season'], data['episode'], data['remoteid']))
-				elif 'season' in data:
-					logger.debug("Manual %s of non-library '%s' S%02d, with an ID of '%s'." % (args['action'], media_type, data['season'], data['remoteid']))
-				else:
-					logger.debug("Manual %s of non-library '%s' with an ID of '%s'." % (args['action'], media_type, data['remoteid']))
+                elif utils.isEpisode(media_type):
+                    result = utils.getEpisodeDetailsFromKodi(data['dbid'], ['showtitle', 'season', 'episode', 'tvshowid', 'uniqueid', 'file', 'playcount'])
+                    if not result:
+                        logger.debug("No data was returned from Kodi, aborting manual %s." % args['action'])
+                        return
+                    data['imdbnumber'] = result['episodeid']
+                    data['season'] = result['season']
+                    data['episode'] = result['episode']
+            else:
+                data['imdbnumber'] = data['remoteid']
+                if 'season' in data and 'episode' in data:
+                    logger.debug("Manual %s of non-library '%s' S%02dE%02d, with an ID of '%s'." % (args['action'], media_type, data['season'], data['episode'], data['remoteid']))
+                elif 'season' in data:
+                    logger.debug("Manual %s of non-library '%s' S%02d, with an ID of '%s'." % (args['action'], media_type, data['season'], data['remoteid']))
+                else:
+                    logger.debug("Manual %s of non-library '%s' with an ID of '%s'." % (args['action'], media_type, data['remoteid']))
 
-			if args['action'] == 'rate' and 'rating' in args:
-				if args['rating'] in ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']:
-					data['rating'] = int(args['rating'])
+            if args['action'] == 'rate' and 'rating' in args:
+                if args['rating'] in ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']:
+                    data['rating'] = int(args['rating'])
 
-			data = {'action': 'manualRating', 'ratingData': data}
+            data = {'action': 'manualRating', 'ratingData': data}
 
-		else:
-			logger.debug("Manual %s of '%s' is unsupported." % (args['action'], media_type))
+        else:
+            logger.debug("Manual %s of '%s' is unsupported." % (args['action'], media_type))
 
-	elif args['action'] == 'togglewatched':
-		media_type = __getMediaType()
-		if media_type in ['movie', 'show', 'season', 'episode']:
-			data = {'media_type': media_type}
-			if utils.isMovie(media_type):
-				dbid = int(xbmc.getInfoLabel('ListItem.DBID'))
-				result = utils.getMovieDetailsFromKodi(dbid, ['imdbnumber', 'title', 'year', 'playcount'])
-				if result:
-					if result['playcount'] == 0:
-						data['id'] = result['imdbnumber']
-					else:
-						logger.debug("Movie alread marked as watched in Kodi.")
-				else:
-					logger.debug("Error getting movie details from Kodi.")
-					return
+    elif args['action'] == 'togglewatched':
+        media_type = __getMediaType()
+        if media_type in ['movie', 'show', 'season', 'episode']:
+            data = {'media_type': media_type}
+            if utils.isMovie(media_type):
+                dbid = int(xbmc.getInfoLabel('ListItem.DBID'))
+                result = utils.getMovieDetailsFromKodi(dbid, ['imdbnumber', 'title', 'year', 'playcount'])
+                if result:
+                    if result['playcount'] == 0:
+                        data['id'] = result['imdbnumber']
+                    else:
+                        logger.debug("Movie alread marked as watched in Kodi.")
+                else:
+                    logger.debug("Error getting movie details from Kodi.")
+                    return
 
-			elif utils.isEpisode(media_type):
-				dbid = int(xbmc.getInfoLabel('ListItem.DBID'))
-				result = utils.getEpisodeDetailsFromKodi(dbid, ['showtitle', 'season', 'episode', 'tvshowid', 'playcount'])
-				if result:
-					if result['playcount'] == 0:
-						data['id'] = result['imdbnumber']
-						data['season'] = result['season']
-						data['number'] = result['episode']
-						data['title'] = result['showtitle']
-					else:
-						logger.debug("Episode already marked as watched in Kodi.")
-				else:
-					logger.debug("Error getting episode details from Kodi.")
-					return
+            elif utils.isEpisode(media_type):
+                dbid = int(xbmc.getInfoLabel('ListItem.DBID'))
+                result = utils.getEpisodeDetailsFromKodi(dbid, ['showtitle', 'season', 'episode', 'tvshowid', 'playcount'])
+                if result:
+                    if result['playcount'] == 0:
+                        data['id'] = result['imdbnumber']
+                        data['season'] = result['season']
+                        data['number'] = result['episode']
+                        data['title'] = result['showtitle']
+                    else:
+                        logger.debug("Episode already marked as watched in Kodi.")
+                else:
+                    logger.debug("Error getting episode details from Kodi.")
+                    return
 
-			elif utils.isSeason(media_type):
-				showID = None
-				showTitle = xbmc.getInfoLabel('ListItem.TVShowTitle')
-				result = utils.kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetTVShows', 'params': {'properties': ['title', 'imdbnumber', 'year']}, 'id': 0})
-				if result and 'tvshows' in result:
-					for show in result['tvshows']:
-						if show['title'] == showTitle:
-							showID = show['tvshowid']
-							data['id'] = show['imdbnumber']
-							data['title'] = show['title']
-							break
-				else:
-					logger.debug("Error getting TV shows from Kodi.")
-					return
+            elif utils.isSeason(media_type):
+                showID = None
+                showTitle = xbmc.getInfoLabel('ListItem.TVShowTitle')
+                result = utils.kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetTVShows', 'params': {'properties': ['title', 'imdbnumber', 'year']}, 'id': 0})
+                if result and 'tvshows' in result:
+                    for show in result['tvshows']:
+                        if show['title'] == showTitle:
+                            showID = show['tvshowid']
+                            data['id'] = show['imdbnumber']
+                            data['title'] = show['title']
+                            break
+                else:
+                    logger.debug("Error getting TV shows from Kodi.")
+                    return
 
-				season = xbmc.getInfoLabel('ListItem.Season')
-				if season == "":
-					season = 0
-				else:
-					season = int(season)
+                season = xbmc.getInfoLabel('ListItem.Season')
+                if season == "":
+                    season = 0
+                else:
+                    season = int(season)
 
-				result = utils.kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetEpisodes', 'params': {'tvshowid': showID, 'season': season, 'properties': ['season', 'episode', 'playcount']}, 'id': 0})
-				if result and 'episodes' in result:
-					episodes = []
-					for episode in result['episodes']:
-						if episode['playcount'] == 0:
-							episodes.append(episode['episode'])
-					
-					if len(episodes) == 0:
-						logger.debug("'%s - Season %d' is already marked as watched." % (showTitle, season))
-						return
+                result = utils.kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetEpisodes', 'params': {'tvshowid': showID, 'season': season, 'properties': ['season', 'episode', 'playcount']}, 'id': 0})
+                if result and 'episodes' in result:
+                    episodes = []
+                    for episode in result['episodes']:
+                        if episode['playcount'] == 0:
+                            episodes.append(episode['episode'])
+                    
+                    if len(episodes) == 0:
+                        logger.debug("'%s - Season %d' is already marked as watched." % (showTitle, season))
+                        return
 
-					data['season'] = season
-					data['episodes'] = episodes
-				else:
-					logger.debug("Error getting episodes from '%s' for Season %d" % (showTitle, season))
-					return
+                    data['season'] = season
+                    data['episodes'] = episodes
+                else:
+                    logger.debug("Error getting episodes from '%s' for Season %d" % (showTitle, season))
+                    return
 
-			elif utils.isShow(media_type):
-				dbid = int(xbmc.getInfoLabel('ListItem.DBID'))
-				result = utils.getShowDetailsFromKodi(dbid, ['year', 'imdbnumber'])
-				if not result:
-					logger.debug("Error getting show details from Kodi.")
-					return
-				showTitle = result['label']
-				data['id'] = result['imdbnumber']
-				result = utils.kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetEpisodes', 'params': {'tvshowid': dbid, 'properties': ['season', 'episode', 'playcount', 'showtitle']}, 'id': 0})
-				if result and 'episodes' in result:
-					i = 0
-					s = {}
-					for e in result['episodes']:
-						data['title'] = e['showtitle']
-						season = str(e['season'])
-						if not season in s:
-							s[season] = []
-						if e['playcount'] == 0:
-							s[season].append(e['episode'])
-							i += 1
+            elif utils.isShow(media_type):
+                dbid = int(xbmc.getInfoLabel('ListItem.DBID'))
+                result = utils.getShowDetailsFromKodi(dbid, ['year', 'imdbnumber'])
+                if not result:
+                    logger.debug("Error getting show details from Kodi.")
+                    return
+                showTitle = result['label']
+                data['id'] = result['imdbnumber']
+                result = utils.kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetEpisodes', 'params': {'tvshowid': dbid, 'properties': ['season', 'episode', 'playcount', 'showtitle']}, 'id': 0})
+                if result and 'episodes' in result:
+                    i = 0
+                    s = {}
+                    for e in result['episodes']:
+                        data['title'] = e['showtitle']
+                        season = str(e['season'])
+                        if not season in s:
+                            s[season] = []
+                        if e['playcount'] == 0:
+                            s[season].append(e['episode'])
+                            i += 1
 
-					if i == 0:
-						logger.debug("'%s' is already marked as watched." % showTitle)
-						return
+                    if i == 0:
+                        logger.debug("'%s' is already marked as watched." % showTitle)
+                        return
 
-					data['seasons'] = dict((k, v) for k, v in s.iteritems() if v)
-				else:
-					logger.debug("Error getting episode details for '%s' from Kodi." % showTitle)
-					return
+                    data['seasons'] = dict((k, v) for k, v in s.iteritems() if v)
+                else:
+                    logger.debug("Error getting episode details for '%s' from Kodi." % showTitle)
+                    return
 
-			if len(data) > 1:
-				logger.debug("Marking '%s' with the following data '%s' as watched on Trakt.tv" % (media_type, str(data)))
-				data['action'] = 'markWatched'
+            if len(data) > 1:
+                logger.debug("Marking '%s' with the following data '%s' as watched on Trakt.tv" % (media_type, str(data)))
+                data['action'] = 'markWatched'
 
-		# execute toggle watched action
-		xbmc.executebuiltin("Action(ToggleWatched)")
+        # execute toggle watched action
+        xbmc.executebuiltin("Action(ToggleWatched)")
 
-	q = sqlitequeue.SqliteQueue()
-	if 'action' in data:
-		logger.debug("Queuing for dispatch: %s" % data)
-		q.append(data)
+    q = sqlitequeue.SqliteQueue()
+    if 'action' in data:
+        logger.debug("Queuing for dispatch: %s" % data)
+        q.append(data)
 
 if __name__ == '__main__':
-	Main()
+    Main()

--- a/scrobbler.py
+++ b/scrobbler.py
@@ -11,259 +11,257 @@ from rating import ratingCheck
 logger = logging.getLogger(__name__)
 
 class Scrobbler():
-	traktapi = None
-	isPlaying = False
-	isPaused = False
-	isMultiPartEpisode = False
-	lastMPCheck = 0
-	curMPEpisode = 0
-	videoDuration = 1
-	watchedTime = 0
-	pausedAt = 0
-	curVideo = None
-	curVideoInfo = None
-	playlistLength = 1
-	playlistIndex = 0
-	traktShowSummary = None
+    traktapi = None
+    isPlaying = False
+    isPaused = False
+    isMultiPartEpisode = False
+    lastMPCheck = 0
+    curMPEpisode = 0
+    videoDuration = 1
+    watchedTime = 0
+    pausedAt = 0
+    curVideo = None
+    curVideoInfo = None
+    playlistLength = 1
+    playlistIndex = 0
+    traktShowSummary = None
 
-	def __init__(self, api):
-		self.traktapi = api
+    def __init__(self, api):
+        self.traktapi = api
 
-	def _currentEpisode(self, watchedPercent, episodeCount):
-		split = (100 / episodeCount)
-		for i in range(episodeCount - 1, 0, -1):
-			if watchedPercent >= (i * split):
-				return i
-		return 0
+    def _currentEpisode(self, watchedPercent, episodeCount):
+        split = (100 / episodeCount)
+        for i in range(episodeCount - 1, 0, -1):
+            if watchedPercent >= (i * split):
+                return i
+        return 0
 
-	def update(self, forceCheck = False):
-		if not xbmc.Player().isPlayingVideo():
-			return
+    def update(self, forceCheck=False):
+        if not xbmc.Player().isPlayingVideo():
+            return
 
-		if self.isPlaying:
-			t = xbmc.Player().getTime()
-			l = xbmc.PlayList(xbmc.PLAYLIST_VIDEO).getposition()
-			if self.playlistIndex == l:
-				self.watchedTime = t
-			else:
-				logger.debug("Current playlist item changed! Not updating time! (%d -> %d)" % (self.playlistIndex, l))
+        if self.isPlaying:
+            t = xbmc.Player().getTime()
+            l = xbmc.PlayList(xbmc.PLAYLIST_VIDEO).getposition()
+            if self.playlistIndex == l:
+                self.watchedTime = t
+            else:
+                logger.debug("Current playlist item changed! Not updating time! (%d -> %d)" % (self.playlistIndex, l))
 
-			if 'id' in self.curVideo and self.isMultiPartEpisode:
-				# do transition check every minute
-				if (time.time() > (self.lastMPCheck + 60)) or forceCheck:
-					self.lastMPCheck = time.time()
-					watchedPercent = self.__calculateWatchedPercent()
-					epIndex = self._currentEpisode(watchedPercent, self.curVideo['multi_episode_count'])
-					if self.curMPEpisode != epIndex:
-						# current episode in multi-part episode has changed
-						logger.debug("Attempting to stop scrobble episode part %d of %d." % (self.curMPEpisode + 1, self.curVideo['multi_episode_count']))
+            if 'id' in self.curVideo and self.isMultiPartEpisode:
+                # do transition check every minute
+                if (time.time() > (self.lastMPCheck + 60)) or forceCheck:
+                    self.lastMPCheck = time.time()
+                    watchedPercent = self.__calculateWatchedPercent()
+                    epIndex = self._currentEpisode(watchedPercent, self.curVideo['multi_episode_count'])
+                    if self.curMPEpisode != epIndex:
+                        # current episode in multi-part episode has changed
+                        logger.debug("Attempting to stop scrobble episode part %d of %d." % (self.curMPEpisode + 1, self.curVideo['multi_episode_count']))
 
-						# recalculate watchedPercent and duration for multi-part, and scrobble
-						adjustedDuration = int(self.videoDuration / self.curVideo['multi_episode_count'])
-						watchedPercent = ((self.watchedTime - (adjustedDuration * self.curMPEpisode)) / adjustedDuration) * 100
-						response = self.traktapi.scrobbleEpisode(self.traktShowSummary, self.curVideoInfo, watchedPercent, 'stop')
-						if response is not None:
-							logger.debug("Scrobble response: %s" % str(response))
+                        # recalculate watchedPercent and duration for multi-part, and scrobble
+                        adjustedDuration = int(self.videoDuration / self.curVideo['multi_episode_count'])
+                        watchedPercent = ((self.watchedTime - (adjustedDuration * self.curMPEpisode)) / adjustedDuration) * 100
+                        response = self.traktapi.scrobbleEpisode(self.traktShowSummary, self.curVideoInfo, watchedPercent, 'stop')
+                        if response is not None:
+                            logger.debug("Scrobble response: %s" % str(response))
 
-						# update current information
-						self.curMPEpisode = epIndex
-						self.curVideoInfo = utilities.kodiRpcToTraktMediaObject('episode', utilities.getEpisodeDetailsFromKodi(self.curVideo['multi_episode_data'][self.curMPEpisode], ['showtitle', 'season', 'episode', 'tvshowid', 'uniqueid', 'file', 'playcount']))
+                        # update current information
+                        self.curMPEpisode = epIndex
+                        self.curVideoInfo = utilities.kodiRpcToTraktMediaObject('episode', utilities.getEpisodeDetailsFromKodi(self.curVideo['multi_episode_data'][self.curMPEpisode], ['showtitle', 'season', 'episode', 'tvshowid', 'uniqueid', 'file', 'playcount']))
 
-						if not forceCheck:
-							logger.debug("Attempting to start scrobble episode part %d of %d." % (self.curMPEpisode + 1, self.curVideo['multi_episode_count']))
-							response = self.traktapi.scrobbleEpisode(self.traktShowSummary, self.curVideoInfo, 0, 'start')
-							if response is not None:
-								logger.debug("Scrobble response: %s" % str(response))
+                        if not forceCheck:
+                            logger.debug("Attempting to start scrobble episode part %d of %d." % (self.curMPEpisode + 1, self.curVideo['multi_episode_count']))
+                            response = self.traktapi.scrobbleEpisode(self.traktShowSummary, self.curVideoInfo, 0, 'start')
+                            if response is not None:
+                                logger.debug("Scrobble response: %s" % str(response))
 
-	def playbackStarted(self, data):
-		logger.debug("playbackStarted(data: %s)" % data)
-		if not data:
-			return
-		self.curVideo = data
-		self.curVideoInfo = None
+    def playbackStarted(self, data):
+        logger.debug("playbackStarted(data: %s)" % data)
+        if not data:
+            return
+        self.curVideo = data
+        self.curVideoInfo = None
 
-		if 'type' in self.curVideo:
-			logger.debug("Watching: %s" % self.curVideo['type'])
-			if not xbmc.Player().isPlayingVideo():
-				logger.debug("Suddenly stopped watching item")
-				return
-			xbmc.sleep(1000) # Wait for possible silent seek (caused by resuming)
-			try:
-				self.watchedTime = xbmc.Player().getTime()
-				self.videoDuration = xbmc.Player().getTotalTime()
-			except Exception as e:
-				logger.debug("Suddenly stopped watching item: %s" % e.message)
-				self.curVideo = None
-				return
+        if 'type' in self.curVideo:
+            logger.debug("Watching: %s" % self.curVideo['type'])
+            if not xbmc.Player().isPlayingVideo():
+                logger.debug("Suddenly stopped watching item")
+                return
+            xbmc.sleep(1000)  # Wait for possible silent seek (caused by resuming)
+            try:
+                self.watchedTime = xbmc.Player().getTime()
+                self.videoDuration = xbmc.Player().getTotalTime()
+            except Exception as e:
+                logger.debug("Suddenly stopped watching item: %s" % e.message)
+                self.curVideo = None
+                return
 
-			if self.videoDuration == 0:
-				if utilities.isMovie(self.curVideo['type']):
-					self.videoDuration = 90
-				elif utilities.isEpisode(self.curVideo['type']):
-					self.videoDuration = 30
-				else:
-					self.videoDuration = 1
+            if self.videoDuration == 0:
+                if utilities.isMovie(self.curVideo['type']):
+                    self.videoDuration = 90
+                elif utilities.isEpisode(self.curVideo['type']):
+                    self.videoDuration = 30
+                else:
+                    self.videoDuration = 1
 
-			self.playlistLength = len(xbmc.PlayList(xbmc.PLAYLIST_VIDEO))
-			self.playlistIndex = xbmc.PlayList(xbmc.PLAYLIST_VIDEO).getposition()
-			if self.playlistLength == 0:
-				logger.debug("Warning: Cant find playlist length, assuming that this item is by itself")
-				self.playlistLength = 1
+            self.playlistLength = len(xbmc.PlayList(xbmc.PLAYLIST_VIDEO))
+            self.playlistIndex = xbmc.PlayList(xbmc.PLAYLIST_VIDEO).getposition()
+            if self.playlistLength == 0:
+                logger.debug("Warning: Cant find playlist length, assuming that this item is by itself")
+                self.playlistLength = 1
 
-			self.isMultiPartEpisode = False
-			if utilities.isMovie(self.curVideo['type']):
-				if 'id' in self.curVideo:
-					self.curVideoInfo = utilities.kodiRpcToTraktMediaObject('movie', utilities.getMovieDetailsFromKodi(self.curVideo['id'], ['imdbnumber', 'title', 'year', 'file', 'lastplayed', 'playcount']))
-				elif 'title' in self.curVideo and 'year' in self.curVideo:
-					self.curVideoInfo = {'title': self.curVideo['title'], 'year': self.curVideo['year']}
+            self.isMultiPartEpisode = False
+            if utilities.isMovie(self.curVideo['type']):
+                if 'id' in self.curVideo:
+                    self.curVideoInfo = utilities.kodiRpcToTraktMediaObject('movie', utilities.getMovieDetailsFromKodi(self.curVideo['id'], ['imdbnumber', 'title', 'year', 'file', 'lastplayed', 'playcount']))
+                elif 'title' in self.curVideo and 'year' in self.curVideo:
+                    self.curVideoInfo = {'title': self.curVideo['title'], 'year': self.curVideo['year']}
 
-			elif utilities.isEpisode(self.curVideo['type']):
-				if 'id' in self.curVideo:
-					episodeDetailsKodi = utilities.getEpisodeDetailsFromKodi(self.curVideo['id'], ['showtitle', 'season', 'episode', 'tvshowid', 'uniqueid', 'file', 'playcount'])
-					tvdb = episodeDetailsKodi['imdbnumber']
-					title, year = utilities.regex_year(episodeDetailsKodi['showtitle'])
-					if not year:
-						self.traktShowSummary = {'title': episodeDetailsKodi['showtitle'], 'year': episodeDetailsKodi['year']}
-					else:
-						self.traktShowSummary = {'title': title, 'year': year}
-					if tvdb:
-						self.traktShowSummary['ids'] = {'tvdb': tvdb}
-					self.curVideoInfo = utilities.kodiRpcToTraktMediaObject('episode', episodeDetailsKodi)
-					if not self.curVideoInfo: # getEpisodeDetailsFromKodi was empty
-						logger.debug("Episode details from Kodi was empty, ID (%d) seems invalid, aborting further scrobbling of this episode." % self.curVideo['id'])
-						self.curVideo = None
-						self.isPlaying = False
-						self.watchedTime = 0
-						return
-				elif 'title' in self.curVideo and 'season' in self.curVideo and 'episode' in self.curVideo:
-					self.curVideoInfo = {'title': self.curVideo['title'], 'season': self.curVideo['season'],
-					                     'number': self.curVideo['episode']}
+            elif utilities.isEpisode(self.curVideo['type']):
+                if 'id' in self.curVideo:
+                    episodeDetailsKodi = utilities.getEpisodeDetailsFromKodi(self.curVideo['id'], ['showtitle', 'season', 'episode', 'tvshowid', 'uniqueid', 'file', 'playcount'])
+                    tvdb = episodeDetailsKodi['imdbnumber']
+                    title, year = utilities.regex_year(episodeDetailsKodi['showtitle'])
+                    if not year:
+                        self.traktShowSummary = {'title': episodeDetailsKodi['showtitle'], 'year': episodeDetailsKodi['year']}
+                    else:
+                        self.traktShowSummary = {'title': title, 'year': year}
+                    if tvdb:
+                        self.traktShowSummary['ids'] = {'tvdb': tvdb}
+                    self.curVideoInfo = utilities.kodiRpcToTraktMediaObject('episode', episodeDetailsKodi)
+                    if not self.curVideoInfo:  # getEpisodeDetailsFromKodi was empty
+                        logger.debug("Episode details from Kodi was empty, ID (%d) seems invalid, aborting further scrobbling of this episode." % self.curVideo['id'])
+                        self.curVideo = None
+                        self.isPlaying = False
+                        self.watchedTime = 0
+                        return
+                elif 'title' in self.curVideo and 'season' in self.curVideo and 'episode' in self.curVideo:
+                    self.curVideoInfo = {'title': self.curVideo['title'], 'season': self.curVideo['season'],
+                                         'number': self.curVideo['episode']}
 
-					title, year = utilities.regex_year(self.curVideo['showtitle'])
-					if not year:
-						self.traktShowSummary = {'title': self.curVideo['showtitle']}
-					else:
-						self.traktShowSummary = {'title': title, 'year': year}
+                    title, year = utilities.regex_year(self.curVideo['showtitle'])
+                    if not year:
+                        self.traktShowSummary = {'title': self.curVideo['showtitle']}
+                    else:
+                        self.traktShowSummary = {'title': title, 'year': year}
 
-					if 'year' in self.curVideo:
-						self.traktShowSummary['year'] = self.curVideo['year']
+                    if 'year' in self.curVideo:
+                        self.traktShowSummary['year'] = self.curVideo['year']
 
-				if 'multi_episode_count' in self.curVideo:
-					self.isMultiPartEpisode = True
+                if 'multi_episode_count' in self.curVideo:
+                    self.isMultiPartEpisode = True
 
-			self.isPlaying = True
-			self.isPaused = False
-			result = self.__scrobble('start')
-			if result:
-				if utilities.isMovie(self.curVideo['type']) and utilities.getSettingAsBool('rate_movie'):
-					# pre-get sumamry information, for faster rating dialog.
-					logger.debug("Movie rating is enabled, pre-fetching summary information.")
-					if result['movie']['ids']['imdb']:
-						self.curVideoInfo['user'] = {'ratings': self.traktapi.getMovieRatingForUser(result['movie']['ids']['imdb'])}
-						self.curVideoInfo['ids'] = result['movie']['ids']
-					else:
-						logger.debug("'%s (%d)' has no valid id, can't get rating." % (self.curVideoInfo['title'], self.curVideoInfo['year']))
-				elif utilities.isEpisode(self.curVideo['type']) and utilities.getSettingAsBool('rate_episode'):
-					# pre-get sumamry information, for faster rating dialog.
-					logger.debug("Episode rating is enabled, pre-fetching summary information.")
+            self.isPlaying = True
+            self.isPaused = False
+            result = self.__scrobble('start')
+            if result:
+                if utilities.isMovie(self.curVideo['type']) and utilities.getSettingAsBool('rate_movie'):
+                    # pre-get sumamry information, for faster rating dialog.
+                    logger.debug("Movie rating is enabled, pre-fetching summary information.")
+                    if result['movie']['ids']['imdb']:
+                        self.curVideoInfo['user'] = {'ratings': self.traktapi.getMovieRatingForUser(result['movie']['ids']['imdb'])}
+                        self.curVideoInfo['ids'] = result['movie']['ids']
+                    else:
+                        logger.debug("'%s (%d)' has no valid id, can't get rating." % (self.curVideoInfo['title'], self.curVideoInfo['year']))
+                elif utilities.isEpisode(self.curVideo['type']) and utilities.getSettingAsBool('rate_episode'):
+                    # pre-get sumamry information, for faster rating dialog.
+                    logger.debug("Episode rating is enabled, pre-fetching summary information.")
 
-					if result['show']['ids']['tvdb']:
-						self.curVideoInfo['user'] = {'ratings' : self.traktapi.getEpisodeRatingForUser(result['show']['ids']['tvdb'], self.curVideoInfo['season'], self.curVideoInfo['number'])}
-						self.curVideoInfo['ids'] = result['episode']['ids']
-					else:
-						logger.debug("'%s - S%02dE%02d' has no valid id, can't get rating." % (self.curVideoInfo['showtitle'], self.curVideoInfo['season'], self.curVideoInfo['episode']))
+                    if result['show']['ids']['tvdb']:
+                        self.curVideoInfo['user'] = {'ratings': self.traktapi.getEpisodeRatingForUser(result['show']['ids']['tvdb'], self.curVideoInfo['season'], self.curVideoInfo['number'])}
+                        self.curVideoInfo['ids'] = result['episode']['ids']
+                    else:
+                        logger.debug("'%s - S%02dE%02d' has no valid id, can't get rating." % (self.curVideoInfo['showtitle'], self.curVideoInfo['season'], self.curVideoInfo['episode']))
 
-	def playbackResumed(self):
-		if not self.isPlaying:
-			return
+    def playbackResumed(self):
+        if not self.isPlaying:
+            return
 
-		logger.debug("playbackResumed()")
-		if self.isPaused:
-			p = time.time() - self.pausedAt
-			logger.debug("Resumed after: %s" % str(p))
-			self.pausedAt = 0
-			self.isPaused = False
-			self.update(True)
-			self.__scrobble('start')
+        logger.debug("playbackResumed()")
+        if self.isPaused:
+            p = time.time() - self.pausedAt
+            logger.debug("Resumed after: %s" % str(p))
+            self.pausedAt = 0
+            self.isPaused = False
+            self.update(True)
+            self.__scrobble('start')
 
-	def playbackPaused(self):
-		if not self.isPlaying:
-			return
+    def playbackPaused(self):
+        if not self.isPlaying:
+            return
 
-		logger.debug("playbackPaused()")
-		self.update(True)
-		logger.debug("Paused after: %s" % str(self.watchedTime))
-		self.isPaused = True
-		self.pausedAt = time.time()
-		self.__scrobble('pause')
+        logger.debug("playbackPaused()")
+        self.update(True)
+        logger.debug("Paused after: %s" % str(self.watchedTime))
+        self.isPaused = True
+        self.pausedAt = time.time()
+        self.__scrobble('pause')
 
-	def playbackSeek(self):
-		if not self.isPlaying:
-			return
+    def playbackSeek(self):
+        if not self.isPlaying:
+            return
 
-		logger.debug("playbackSeek()")
-		self.update(True)
-		self.__scrobble('start')
+        logger.debug("playbackSeek()")
+        self.update(True)
+        self.__scrobble('start')
 
-	def playbackEnded(self):
-		if not self.isPlaying:
-			return
+    def playbackEnded(self):
+        if not self.isPlaying:
+            return
 
-		logger.debug("playbackEnded()")
-		if self.curVideo is None:
-			logger.debug("Warning: Playback ended but video forgotten.")
-			return
-		self.isPlaying = False
-		if self.watchedTime != 0:
-			if 'type' in self.curVideo:
-				self.__scrobble('stop')
-				ratingCheck(self.curVideo['type'], self.curVideoInfo, self.watchedTime, self.videoDuration, self.playlistLength)
-			self.watchedTime = 0
-			self.isMultiPartEpisode = False
-		self.curVideoInfo = None
-		self.curVideo = None
-		self.playlistLength = 0
-		self.playlistIndex = 0
+        logger.debug("playbackEnded()")
+        if self.curVideo is None:
+            logger.debug("Warning: Playback ended but video forgotten.")
+            return
+        self.isPlaying = False
+        if self.watchedTime != 0:
+            if 'type' in self.curVideo:
+                self.__scrobble('stop')
+                ratingCheck(self.curVideo['type'], self.curVideoInfo, self.watchedTime, self.videoDuration, self.playlistLength)
+            self.watchedTime = 0
+            self.isMultiPartEpisode = False
+        self.curVideoInfo = None
+        self.curVideo = None
+        self.playlistLength = 0
+        self.playlistIndex = 0
 
-	def __calculateWatchedPercent(self):
-		return (self.watchedTime / math.floor(self.videoDuration)) * 100 #we need to floor this, so this calculation yields the same result as the playback progress calculation
+    def __calculateWatchedPercent(self):
+        return (self.watchedTime / math.floor(self.videoDuration)) * 100  # we need to floor this, so this calculation yields the same result as the playback progress calculation
 
-	def __scrobble(self, status):
-		if not self.curVideoInfo:
-			return
+    def __scrobble(self, status):
+        if not self.curVideoInfo:
+            return
 
-		logger.debug("scrobble()")
-		scrobbleMovieOption = utilities.getSettingAsBool('scrobble_movie')
-		scrobbleEpisodeOption = utilities.getSettingAsBool('scrobble_episode')
+        logger.debug("scrobble()")
+        scrobbleMovieOption = utilities.getSettingAsBool('scrobble_movie')
+        scrobbleEpisodeOption = utilities.getSettingAsBool('scrobble_episode')
 
-		watchedPercent = self.__calculateWatchedPercent()
+        watchedPercent = self.__calculateWatchedPercent()
 
-		if utilities.isMovie(self.curVideo['type']) and scrobbleMovieOption:
-			response = self.traktapi.scrobbleMovie(self.curVideoInfo, watchedPercent, status)
-			if not response is None:
-				self.__scrobbleNotification(response)
-				logger.debug("Scrobble response: %s" % str(response))
-				return response
+        if utilities.isMovie(self.curVideo['type']) and scrobbleMovieOption:
+            response = self.traktapi.scrobbleMovie(self.curVideoInfo, watchedPercent, status)
+            if not response is None:
+                self.__scrobbleNotification(response)
+                logger.debug("Scrobble response: %s" % str(response))
+                return response
 
-		elif utilities.isEpisode(self.curVideo['type']) and scrobbleEpisodeOption:
-			if self.isMultiPartEpisode:
-				logger.debug("Multi-part episode, scrobbling part %d of %d." % (self.curMPEpisode + 1, self.curVideo['multi_episode_count']))
-				adjustedDuration = int(self.videoDuration / self.curVideo['multi_episode_count'])
-				watchedPercent = ((self.watchedTime - (adjustedDuration * self.curMPEpisode)) / adjustedDuration) * 100
+        elif utilities.isEpisode(self.curVideo['type']) and scrobbleEpisodeOption:
+            if self.isMultiPartEpisode:
+                logger.debug("Multi-part episode, scrobbling part %d of %d." % (self.curMPEpisode + 1, self.curVideo['multi_episode_count']))
+                adjustedDuration = int(self.videoDuration / self.curVideo['multi_episode_count'])
+                watchedPercent = ((self.watchedTime - (adjustedDuration * self.curMPEpisode)) / adjustedDuration) * 100
 
-			response = self.traktapi.scrobbleEpisode(self.traktShowSummary, self.curVideoInfo, watchedPercent, status)
+            response = self.traktapi.scrobbleEpisode(self.traktShowSummary, self.curVideoInfo, watchedPercent, status)
 
-			if not response is None:
-				self.__scrobbleNotification(response)
-				logger.debug("Scrobble response: %s" % str(response))
-				return response
+            if not response is None:
+                self.__scrobbleNotification(response)
+                logger.debug("Scrobble response: %s" % str(response))
+                return response
 
+    def __scrobbleNotification(self, info):
+        if not self.curVideoInfo:
+            return
 
-	def __scrobbleNotification(self, info):
-		if not self.curVideoInfo:
-			return
-		
-		if utilities.getSettingAsBool("scrobble_notification"):
-			s = utilities.getFormattedItemName(self.curVideo['type'], info[self.curVideo['type']])
-			utilities.notification(utilities.getString(32015), s)
-
+        if utilities.getSettingAsBool("scrobble_notification"):
+            s = utilities.getFormattedItemName(self.curVideo['type'], info[self.curVideo['type']])
+            utilities.notification(utilities.getString(32015), s)

--- a/sqlitequeue.py
+++ b/sqlitequeue.py
@@ -5,17 +5,17 @@ import sys
 import sqlite3
 import utilities as utils
 
-if sys.version_info >=  (2, 7):
-	from json import loads, dumps
+if sys.version_info >= (2, 7):
+    from json import loads, dumps
 else:
-	from simplejson import loads, dumps
+    from simplejson import loads, dumps
 
 from time import sleep
 
 try:
-	from thread import get_ident
+    from thread import get_ident
 except ImportError:
-	from dummy_thread import get_ident
+    from dummy_thread import get_ident
 
 import xbmc
 import xbmcvfs
@@ -29,93 +29,93 @@ __addon__ = xbmcaddon.Addon('script.trakt')
 # code from http://flask.pocoo.org/snippets/88/ with some modifications
 class SqliteQueue(object):
 
-	_create = (
-				'CREATE TABLE IF NOT EXISTS queue ' 
-				'('
-				'  id INTEGER PRIMARY KEY AUTOINCREMENT,'
-				'  item BLOB'
-				')'
-				)
-	_count = 'SELECT COUNT(*) FROM queue'
-	_iterate = 'SELECT id, item FROM queue'
-	_append = 'INSERT INTO queue (item) VALUES (?)'
-	_write_lock = 'BEGIN IMMEDIATE'
-	_get = (
-			'SELECT id, item FROM queue '
-			'ORDER BY id LIMIT 1'
-			)
-	_del = 'DELETE FROM queue WHERE id = ?'
-	_peek = (
-			'SELECT item FROM queue '
-			'ORDER BY id LIMIT 1'
-			)
-	_purge = 'DELETE FROM queue'
+    _create = (
+                'CREATE TABLE IF NOT EXISTS queue '
+                '('
+                '  id INTEGER PRIMARY KEY AUTOINCREMENT,'
+                '  item BLOB'
+                ')'
+                )
+    _count = 'SELECT COUNT(*) FROM queue'
+    _iterate = 'SELECT id, item FROM queue'
+    _append = 'INSERT INTO queue (item) VALUES (?)'
+    _write_lock = 'BEGIN IMMEDIATE'
+    _get = (
+            'SELECT id, item FROM queue '
+            'ORDER BY id LIMIT 1'
+            )
+    _del = 'DELETE FROM queue WHERE id = ?'
+    _peek = (
+            'SELECT item FROM queue '
+            'ORDER BY id LIMIT 1'
+            )
+    _purge = 'DELETE FROM queue'
 
-	def __init__(self):
-		self.path = xbmc.translatePath(__addon__.getAddonInfo("profile")).decode("utf-8")
-		if not xbmcvfs.exists(self.path):
-			logger.debug("Making path structure: %s" % repr(self.path))
-			xbmcvfs.mkdir(self.path)
-		self.path = os.path.join(self.path, 'queue.db')
-		self._connection_cache = {}
-		with self._get_conn() as conn:
-			conn.execute(self._create)
+    def __init__(self):
+        self.path = xbmc.translatePath(__addon__.getAddonInfo("profile")).decode("utf-8")
+        if not xbmcvfs.exists(self.path):
+            logger.debug("Making path structure: %s" % repr(self.path))
+            xbmcvfs.mkdir(self.path)
+        self.path = os.path.join(self.path, 'queue.db')
+        self._connection_cache = {}
+        with self._get_conn() as conn:
+            conn.execute(self._create)
 
-	def __len__(self):
-		with self._get_conn() as conn:
-			l = conn.execute(self._count).next()[0]
-		return l
+    def __len__(self):
+        with self._get_conn() as conn:
+            l = conn.execute(self._count).next()[0]
+        return l
 
-	def __iter__(self):
-		with self._get_conn() as conn:
-			for id, obj_buffer in conn.execute(self._iterate):
-				yield loads(str(obj_buffer))
+    def __iter__(self):
+        with self._get_conn() as conn:
+            for id, obj_buffer in conn.execute(self._iterate):
+                yield loads(str(obj_buffer))
 
-	def _get_conn(self):
-		id = get_ident()
-		if id not in self._connection_cache:
-			self._connection_cache[id] = sqlite3.Connection(self.path, timeout=60)
-		return self._connection_cache[id]
+    def _get_conn(self):
+        id = get_ident()
+        if id not in self._connection_cache:
+            self._connection_cache[id] = sqlite3.Connection(self.path, timeout=60)
+        return self._connection_cache[id]
 
-	def purge(self):
-		with self._get_conn() as conn:
-			conn.execute(self._purge)
+    def purge(self):
+        with self._get_conn() as conn:
+            conn.execute(self._purge)
 
-	def append(self, obj):
-		obj_buffer = dumps(obj)
-		with self._get_conn() as conn:
-			conn.execute(self._append, (obj_buffer,)) 
+    def append(self, obj):
+        obj_buffer = dumps(obj)
+        with self._get_conn() as conn:
+            conn.execute(self._append, (obj_buffer,))
 
-	def get(self, sleep_wait=True):
-		keep_pooling = True
-		wait = 0.1
-		max_wait = 2
-		tries = 0
-		with self._get_conn() as conn:
-			id = None
-			while keep_pooling:
-				conn.execute(self._write_lock)
-				cursor = conn.execute(self._get)
-				try:
-					id, obj_buffer = cursor.next()
-					keep_pooling = False
-				except StopIteration:
-					conn.commit() # unlock the database
-					if not sleep_wait:
-						keep_pooling = False
-						continue
-					tries += 1
-					sleep(wait)
-					wait = min(max_wait, tries/10 + wait)
-			if id:
-				conn.execute(self._del, (id,))
-				return loads(str(obj_buffer))
-		return None
+    def get(self, sleep_wait=True):
+        keep_pooling = True
+        wait = 0.1
+        max_wait = 2
+        tries = 0
+        with self._get_conn() as conn:
+            id = None
+            while keep_pooling:
+                conn.execute(self._write_lock)
+                cursor = conn.execute(self._get)
+                try:
+                    id, obj_buffer = cursor.next()
+                    keep_pooling = False
+                except StopIteration:
+                    conn.commit()  # unlock the database
+                    if not sleep_wait:
+                        keep_pooling = False
+                        continue
+                    tries += 1
+                    sleep(wait)
+                    wait = min(max_wait, tries / 10 + wait)
+            if id:
+                conn.execute(self._del, (id,))
+                return loads(str(obj_buffer))
+        return None
 
-	def peek(self):
-		with self._get_conn() as conn:
-			cursor = conn.execute(self._peek)
-			try:
-				return loads(str(cursor.next()[0]))
-			except StopIteration:
-				return None
+    def peek(self):
+        with self._get_conn() as conn:
+            cursor = conn.execute(self._peek)
+            try:
+                return loads(str(cursor.next()[0]))
+            except StopIteration:
+                return None

--- a/sync.py
+++ b/sync.py
@@ -11,943 +11,937 @@ progress = xbmcgui.DialogProgress()
 logger = logging.getLogger(__name__)
 
 class Sync():
-
-
-	def __init__(self, show_progress=False, run_silent=False, library="all", api=None):
-		self.traktapi = api
-		self.show_progress = show_progress
-		self.run_silent = run_silent
-		self.library = library
-		if self.show_progress and self.run_silent:
-			logger.debug("Sync is being run silently.")
-		self.sync_on_update = utilities.getSettingAsBool('sync_on_update')
-		self.notify = utilities.getSettingAsBool('show_sync_notifications')
-		self.notify_during_playback = not (xbmc.Player().isPlayingVideo() and utilities.getSettingAsBool("hide_notifications_playback"))
-
-	def __isCanceled(self):
-		if self.show_progress and not self.run_silent and progress.iscanceled():
-			logger.debug("Sync was canceled by user.")
-			return True
-		elif xbmc.abortRequested:
-			logger.debug('Kodi abort requested')
-			return True
-		else:
-			return False
-
-	def __updateProgress(self, *args, **kwargs):
-		if self.show_progress and not self.run_silent:
-			kwargs['percent'] = args[0]
-			progress.update(**kwargs)
-
-	''' begin code for episode sync '''
-	def __kodiLoadShows(self):
-		self.__updateProgress(1, line1=utilities.getString(32094), line2=utilities.getString(32095))
-
-		logger.debug("[Episodes Sync] Getting show data from Kodi")
-		data = utilities.kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetTVShows', 'params': {'properties': ['title', 'imdbnumber', 'year']}, 'id': 0})
-		if data['limits']['total'] == 0:
-			logger.debug("[Episodes Sync] Kodi json request was empty.")
-			return None, None
-
-		tvshows = utilities.kodiRpcToTraktMediaObjects(data)
-		logger.debug("[Episode Sync] Getting shows from kodi finished %s" % tvshows)
-
-		if tvshows is None:
-			return None, None
-		self.__updateProgress(2, line2=utilities.getString(32096))
-		resultCollected = {'shows': []}
-		resultWatched = {'shows': []}
-		i = 0
-		x = float(len(tvshows))
-		logger.debug("[Episodes Sync] Getting episode data from Kodi")
-		for show_col1 in tvshows:
-			i += 1
-			y = ((i / x) * 8) + 2
-			self.__updateProgress(int(y), line2=utilities.getString(32097) % (i, x))
-
-			show = {'title': show_col1['title'], 'ids': {}, 'year': show_col1['year'], 'seasons': []}
-
-			if 'ids' in show_col1 and 'tvdb' in show_col1['ids']:
-				show['ids'] = {'tvdb': show_col1['ids']['tvdb']}
-
-			data = utilities.kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetEpisodes', 'params': {'tvshowid': show_col1['tvshowid'], 'properties': ['season', 'episode', 'playcount', 'uniqueid', 'lastplayed', 'file', 'dateadded', 'runtime']}, 'id': 0})
-			if not data:
-				logger.debug("[Episodes Sync] There was a problem getting episode data for '%s', aborting sync." % show['title'])
-				return None, None
-			elif 'episodes' not in data:
-				logger.debug("[Episodes Sync] '%s' has no episodes in Kodi." % show['title'])
-				continue
-
-			if 'tvshowid' in show_col1:
-				del(show_col1['tvshowid'])
-
-			showWatched = copy.deepcopy(show)
-			data2 = copy.deepcopy(data)
-			show['seasons'] = utilities.kodiRpcToTraktMediaObjects(data)
-
-			showWatched['seasons'] = utilities.kodiRpcToTraktMediaObjects(data2, 'watched')
-
-			resultCollected['shows'].append(show)
-			resultWatched['shows'].append(showWatched)
-
-		self.__updateProgress(10, line2=utilities.getString(32098))
-		return resultCollected, resultWatched
-
-	def __traktLoadShows(self):
-		self.__updateProgress(10, line1=utilities.getString(32099), line2=utilities.getString(32100))
-
-		logger.debug('[Episodes Sync] Getting episode collection from Trakt.tv')
-		try:
-			traktShowsCollected = {}
-			traktShowsCollected = self.traktapi.getShowsCollected(traktShowsCollected)
-			traktShowsCollected = traktShowsCollected.items()
-
-			self.__updateProgress(12, line2=utilities.getString(32101))
-			traktShowsWatched = {}
-			traktShowsWatched = self.traktapi.getShowsWatched(traktShowsWatched)
-			traktShowsWatched = traktShowsWatched.items()
-		except Exception:
-			logger.debug("[Episodes Sync] Invalid Trakt.tv show list, possible error getting data from Trakt, aborting Trakt.tv collection update.")
-			return False, False
-
-		i = 0
-		x = float(len(traktShowsCollected))
-		showsCollected = {'shows': []}
-		for key, show in traktShowsCollected:
-			i += 1
-			y = ((i / x) * 20) + 6
-			self.__updateProgress(int(y), line2=utilities.getString(32102) % (i, x))
-
-			#will keep the data in python structures - just like the KODI response
-			show = show.to_dict()
-			
-			showsCollected['shows'].append(show)
-
-		i = 0
-		x = float(len(traktShowsWatched))
-		showsWatched = {'shows': []}
-		for key, show in traktShowsWatched:
-			i += 1
-			y = ((i / x) * 26) + 6
-			self.__updateProgress(int(y), line2=utilities.getString(32102) % (i, x))
-
-			#will keep the data in python structures - just like the KODI response
-			show = show.to_dict()
-
-			showsWatched['shows'].append(show)
-
-		self.__updateProgress(32, line2=utilities.getString(32103))
-
-		return showsCollected, showsWatched
-
-	def __traktLoadShowsPlaybackProgress(self):
-		if utilities.getSettingAsBool('trakt_episode_playback') and not self.__isCanceled():
-			self.__updateProgress(10, line1=utilities.getString(1485), line2=utilities.getString(32119))
-
-			logger.debug('[Playback Sync] Getting playback progress from Trakt.tv')
-			try:
-				traktProgressShows = self.traktapi.getEpisodePlaybackProgress()
-			except Exception:
-				logger.debug("[Playback Sync] Invalid Trakt.tv progress list, possible error getting data from Trakt, aborting Trakt.tv playback update.")
-				return False
-
-			i = 0
-			x = float(len(traktProgressShows))
-			showsProgress = {'shows': []}
-			for show in traktProgressShows:
-				i += 1
-				y = ((i / x) * 20) + 6
-				self.__updateProgress(int(y), line2=utilities.getString(32120) % (i, x))
-
-				#will keep the data in python structures - just like the KODI response
-				show = show.to_dict()
-
-				showsProgress['shows'].append(show)
-
-			self.__updateProgress(32, line2=utilities.getString(32121))
-
-			return showsProgress
-
-	def __addEpisodesToTraktCollection(self, kodiShows, traktShows):
-		if utilities.getSettingAsBool('add_episodes_to_trakt') and not self.__isCanceled():
-			addTraktShows = copy.deepcopy(traktShows)
-			addKodiShows = copy.deepcopy(kodiShows)
-
-			tmpTraktShowsAdd = self.__compareShows(addKodiShows, addTraktShows)
-			traktShowsAdd = copy.deepcopy(tmpTraktShowsAdd)
-			self.sanitizeShows(traktShowsAdd)
-			#logger.debug("traktShowsAdd %s" % traktShowsAdd)
-
-			if len(traktShowsAdd['shows']) == 0:
-				self.__updateProgress(48, line1=utilities.getString(32068), line2=utilities.getString(32104))
-				logger.debug("[Episodes Sync] Trakt.tv episode collection is up to date.")
-				return
-			logger.debug("[Episodes Sync] %i show(s) have episodes (%d) to be added to your Trakt.tv collection." % (len(traktShowsAdd['shows']), self.__countEpisodes(traktShowsAdd)))
-			for show in traktShowsAdd['shows']:
-				logger.debug("[Episodes Sync] Episodes added: %s" % self.__getShowAsString(show, short=True))
-
-			self.__updateProgress(33, line1=utilities.getString(32068), line2=utilities.getString(32067) % (len(traktShowsAdd['shows'])), line3=" ")
-
-			#split episode list into chunks of 50
-			chunksize = 1
-			chunked_episodes = utilities.chunks(traktShowsAdd['shows'], chunksize)
-			errorcount = 0
-			i = 0
-			x = float(len(traktShowsAdd['shows']))
-			for chunk in chunked_episodes:
-				if self.__isCanceled():
-					return
-				i += 1
-				y = ((i / x) * 16) + 33
-				self.__updateProgress(int(y), line2=utilities.getString(32069) % ((i)*chunksize if (i)*chunksize < x else x, x))
-
-				request = {'shows': chunk}
-				logger.debug("[traktAddEpisodes] Shows to add %s" % request)
-				try:
-					self.traktapi.addToCollection(request)
-				except Exception as ex:
-					message = utilities.createError(ex)
-					logging.fatal(message)
-					errorcount += 1
-
-			logger.debug("[traktAddEpisodes] Finished with %d error(s)" % errorcount)
-			self.__updateProgress(49, line2=utilities.getString(32105) % self.__countEpisodes(traktShowsAdd))
-
-	def __deleteEpisodesFromTraktCollection(self, traktShows, kodiShows):
-		if utilities.getSettingAsBool('clean_trakt_episodes') and not self.__isCanceled():
-			removeTraktShows = copy.deepcopy(traktShows)
-			removeKodiShows = copy.deepcopy(kodiShows)
-
-			traktShowsRemove = self.__compareShows(removeTraktShows, removeKodiShows)
-			self.sanitizeShows(traktShowsRemove)
-
-			if len(traktShowsRemove['shows']) == 0:
-				self.__updateProgress(65, line1=utilities.getString(32077), line2=utilities.getString(32110))
-				logger.debug('[Episodes Sync] Trakt.tv episode collection is clean, no episodes to remove.')
-				return
-
-			logger.debug("[Episodes Sync] %i show(s) will have episodes removed from Trakt.tv collection." % len(traktShowsRemove['shows']))
-			for show in traktShowsRemove['shows']:
-				logger.debug("[Episodes Sync] Episodes removed: %s" % self.__getShowAsString(show, short=True))
-
-			self.__updateProgress(50, line1=utilities.getString(32077), line2=utilities.getString(32111) % self.__countEpisodes(traktShowsRemove), line3=" ")
-
-			logger.debug("[traktRemoveEpisodes] Shows to remove %s" % traktShowsRemove)
-			try:
-				self.traktapi.removeFromCollection(traktShowsRemove)
-			except Exception as ex:
-				message = utilities.createError(ex)
-				logging.fatal(message)
-
-			self.__updateProgress(65, line2=utilities.getString(32112) % self.__countEpisodes(traktShowsRemove), line3=" ")
-
-	def __addEpisodesToTraktWatched(self, kodiShows, traktShows):
-		if utilities.getSettingAsBool('trakt_episode_playcount') and not self.__isCanceled():
-			updateTraktTraktShows = copy.deepcopy(traktShows)
-			updateTraktKodiShows = copy.deepcopy(kodiShows)
-
-			traktShowsUpdate = self.__compareShows(updateTraktKodiShows, updateTraktTraktShows, watched=True)
-			self.sanitizeShows(traktShowsUpdate)
-			#logger.debug("traktShowsUpdate %s" % traktShowsUpdate)
-
-			if len(traktShowsUpdate['shows']) == 0:
-				self.__updateProgress(82, line1=utilities.getString(32071), line2=utilities.getString(32106))
-				logger.debug("[Episodes Sync] Trakt.tv episode playcounts are up to date.")
-				return
-
-			logger.debug("[Episodes Sync] %i show(s) are missing playcounts on Trakt.tv" % len(traktShowsUpdate['shows']))
-			for show in traktShowsUpdate['shows']:
-				logger.debug("[Episodes Sync] Episodes updated: %s" % self.__getShowAsString(show, short=True))
-
-			self.__updateProgress(66, line1=utilities.getString(32071), line2=utilities.getString(32070) % (len(traktShowsUpdate['shows'])), line3="")
-			errorcount = 0
-			i = 0
-			x = float(len(traktShowsUpdate['shows']))
-			for show in traktShowsUpdate['shows']:
-				if self.__isCanceled():
-					return
-				epCount = self.__countEpisodes([show])
-				title = show['title'].encode('utf-8', 'ignore')
-				i += 1
-				y = ((i / x) * 16) + 66
-				self.__updateProgress(int(y), line2=title, line3=utilities.getString(32073) % epCount)
-
-				s = {'shows': [show]}
-				logger.debug("[traktUpdateEpisodes] Shows to update %s" % s)
-				try:
-					self.traktapi.addToHistory(s)
-				except Exception as ex:
-					message = utilities.createError(ex)
-					logging.fatal(message)
-					errorcount += 1
-
-			logger.debug("[traktUpdateEpisodes] Finished with %d error(s)" % errorcount)
-			self.__updateProgress(82, line2=utilities.getString(32072) % (len(traktShowsUpdate['shows'])), line3="")
-
-	def __addEpisodesToKodiWatched(self, traktShows, kodiShows, kodiShowsCollected):
-		if utilities.getSettingAsBool('kodi_episode_playcount') and not self.__isCanceled():
-			updateKodiTraktShows = copy.deepcopy(traktShows)
-			updateKodiKodiShows = copy.deepcopy(kodiShows)
-
-			kodiShowsUpadate = self.__compareShows(updateKodiTraktShows, updateKodiKodiShows, watched=True, restrict=True, collected=kodiShowsCollected)
-
-			if len(kodiShowsUpadate['shows']) == 0:
-				self.__updateProgress(98, line1=utilities.getString(32074), line2=utilities.getString(32107))
-				logger.debug("[Episodes Sync] Kodi episode playcounts are up to date.")
-				return
-
-			logger.debug("[Episodes Sync] %i show(s) shows are missing playcounts on Kodi" % len(kodiShowsUpadate['shows']))
-			for s in ["%s" % self.__getShowAsString(s, short=True) for s in kodiShowsUpadate['shows']]:
-				logger.debug("[Episodes Sync] Episodes updated: %s" % s)
-
-			#logger.debug("kodiShowsUpadate: %s" % kodiShowsUpadate)
-			episodes = []
-			for show in kodiShowsUpadate['shows']:
-				for season in show['seasons']:
-					for episode in season['episodes']:
-						episodes.append({'episodeid': episode['ids']['episodeid'], 'playcount': episode['plays'], "lastplayed": utilities.convertUtcToDateTime(episode['last_watched_at'])})
-
-			#split episode list into chunks of 50
-			chunksize = 50
-			chunked_episodes = utilities.chunks([{"jsonrpc": "2.0", "method": "VideoLibrary.SetEpisodeDetails", "params": episodes[i], "id": i} for i in range(len(episodes))], chunksize)
-			i = 0
-			x = float(len(episodes))
-			for chunk in chunked_episodes:
-				if self.__isCanceled():
-					return
-				i += 1
-				y = ((i / x) * 16) + 82
-				self.__updateProgress(int(y), line2=utilities.getString(32108) % ((i)*chunksize if (i)*chunksize < x else x, x))
-
-				logger.debug("[Episodes Sync] chunk %s" % str(chunk))
-				result = utilities.kodiJsonRequest(chunk)
-				logger.debug("[Episodes Sync] result %s" % str(result))
-
-			self.__updateProgress(98, line2=utilities.getString(32109) % len(episodes))
-
-	def __addEpisodeProgressToKodi(self, traktShows, kodiShows):
-		if utilities.getSettingAsBool('trakt_episode_playback') and traktShows and not self.__isCanceled():
-			updateKodiTraktShows = copy.deepcopy(traktShows)
-			updateKodiKodiShows = copy.deepcopy(kodiShows)
-			kodiShowsUpadate = self.__compareShows(updateKodiTraktShows, updateKodiKodiShows, restrict=True, playback=True)
-
-			if len(kodiShowsUpadate['shows']) == 0:
-				self.__updateProgress(98, line1=utilities.getString(1441), line2=utilities.getString(32129))
-				logger.debug("[Episodes Sync] Kodi episode playbacks are up to date.")
-				return
-
-			logger.debug("[Episodes Sync] %i show(s) shows are missing playbacks on Kodi" % len(kodiShowsUpadate['shows']))
-			for s in ["%s" % self.__getShowAsString(s, short=True) for s in kodiShowsUpadate['shows']]:
-				logger.debug("[Episodes Sync] Episodes updated: %s" % s)
-
-			episodes = []
-			for show in kodiShowsUpadate['shows']:
-				for season in show['seasons']:
-					for episode in season['episodes']:
-						episodes.append({'episodeid': episode['ids']['episodeid'], 'progress': episode['progress'], 'runtime': episode['runtime']})
-
-			#need to calculate the progress in int from progress in percent from Trakt
-			#split episode list into chunks of 50
-			chunksize = 50
-			chunked_episodes = utilities.chunks([{"jsonrpc": "2.0", "id": i, "method": "VideoLibrary.SetEpisodeDetails", "params": {"episodeid":episodes[i]['episodeid'], "resume": {"position": episodes[i]['runtime']/100.0*episodes[i]['progress']}}} for i in range(len(episodes))], chunksize)
-			i = 0
-			x = float(len(episodes))
-			for chunk in chunked_episodes:
-				if self.__isCanceled():
-					return
-				i += 1
-				y = ((i / x) * 16) + 82
-				self.__updateProgress(int(y), line2=utilities.getString(32130) % ((i)*chunksize if (i)*chunksize < x else x, x))
-
-				utilities.kodiJsonRequest(chunk)
-
-			self.__updateProgress(98, line2=utilities.getString(32131) % len(episodes))
-
-	def __countEpisodes(self, shows, collection=True):
-		count = 0
-		if 'shows' in shows:
-			shows = shows['shows']
-		for show in shows:
-			for seasonKey in show['seasons']:
-				if seasonKey is not None and 'episodes' in seasonKey:
-					for episodeKey in seasonKey['episodes']:
-						if episodeKey is not None:
-							if 'collected' in episodeKey and not episodeKey['collected'] == collection:
-								continue
-							if 'number' in episodeKey and episodeKey['number']:
-								count += 1
-		return count
-
-	def __getShowAsString(self, show, short=False):
-		p = []
-		if 'seasons' in show:
-			for season in show['seasons']:
-				s = ""
-				if short:
-					s = ", ".join(["S%02dE%02d" % (season['number'], i['number']) for i in season['episodes']])
-				else:
-					episodes = ", ".join([str(i) for i in show['shows']['seasons'][season]])
-					s = "Season: %d, Episodes: %s" % (season, episodes)
-				p.append(s)
-		else:
-			p = ["All"]
-		if 'tvdb' in show['ids']:
-			return "%s [tvdb: %s] - %s" % (show['title'], show['ids']['tvdb'], ", ".join(p))
-		else:
-			return "%s [tvdb: No id] - %s" % (show['title'], ", ".join(p))
-
-	def __getEpisodes(self, seasons):
-		data = {}
-		for season in seasons:
-			episodes = {}
-			for episode in season['episodes']:
-				episodes[episode['number']] = episode
-			data[season['number']] = episodes
-
-		return data
-
-	#always return shows_col1 if you have enrich it, but don't return shows_col2
-	def __compareShows(self, shows_col1, shows_col2, watched=False, restrict=False, collected=False, playback=False):
-		shows = []
-		for show_col1 in shows_col1['shows']:
-			if show_col1:
-				show_col2 = utilities.findMediaObject(show_col1, shows_col2['shows'])
-				#logger.debug("show_col1 %s" % show_col1)
-				#logger.debug("show_col2 %s" % show_col2)
-
-				if show_col2:
-					season_diff = {}
-					# format the data to be easy to compare Trakt and KODI data
-					season_col1 = self.__getEpisodes(show_col1['seasons'])
-					season_col2 = self.__getEpisodes(show_col2['seasons'])
-					for season in season_col1:
-						a = season_col1[season]
-						if season in season_col2:
-							b = season_col2[season]
-							diff = list(set(a).difference(set(b)))
-							if playback:
-								t = list(set(a).intersection(set(b)))
-								if len(t) > 0:
-									eps = {}
-									for ep in t:
-										eps[ep] = a[ep]
-										if 'episodeid' in season_col2[season][ep]['ids']:
-											if 'ids' in eps:
-												eps[ep]['ids']['episodeid'] = season_col2[season][ep]['ids']['episodeid']
-											else:
-												eps[ep]['ids'] = {'episodeid': season_col2[season][ep]['ids']['episodeid']}
-										eps[ep]['runtime'] = season_col2[season][ep]['runtime']
-									season_diff[season] = eps
-							elif len(diff) > 0:
-								if restrict:
-									# get all the episodes that we have in Kodi, watched or not - update kodi
-									collectedShow = utilities.findMediaObject(show_col1, collected['shows'])
-									#logger.debug("collected %s" % collectedShow)
-									collectedSeasons = self.__getEpisodes(collectedShow['seasons'])
-									t = list(set(collectedSeasons[season]).intersection(set(diff)))
-									if len(t) > 0:
-										eps = {}
-										for ep in t:
-											eps[ep] = a[ep]
-											if 'episodeid' in collectedSeasons[season][ep]['ids']:
-												if 'ids' in eps:
-													eps[ep]['ids']['episodeid'] = collectedSeasons[season][ep]['ids']['episodeid']
-												else:
-													eps[ep]['ids'] = {'episodeid': collectedSeasons[season][ep]['ids']['episodeid']}
-										season_diff[season] = eps
-								else:
-									eps = {}
-									for ep in diff:
-										eps[ep] = a[ep]
-									if len(eps) > 0:
-										season_diff[season] = eps
-						else:
-							if not restrict:
-								if len(a) > 0:
-									season_diff[season] = a
-					#logger.debug("season_diff %s" % season_diff)
-					if len(season_diff) > 0:
-						#logger.debug("Season_diff")
-						show = {'title': show_col1['title'], 'ids': {}, 'year': show_col1['year'], 'seasons': []}
-						if 'tvdb' in show_col1['ids']:
-							show['ids'] = {'tvdb': show_col1['ids']['tvdb']}
-						for seasonKey in season_diff:
-							episodes = []
-							for episodeKey in season_diff[seasonKey]:
-								episodes.append(season_diff[seasonKey][episodeKey])
-							show['seasons'].append({ 'number': seasonKey, 'episodes': episodes })
-						if 'imdb' in show_col2 and show_col2['imdb']:
-							show['ids']['imdb'] = show_col2['imdb']
-						if 'tvshowid' in show_col2:
-							show['tvshowid'] = show_col2['tvshowid']
-						#logger.debug("show %s" % show)
-						shows.append(show)
-				else:
-					if not restrict:
-						if self.__countEpisodes([show_col1]) > 0:
-							show = {'title': show_col1['title'], 'ids': {}, 'year': show_col1['year'], 'seasons': []}
-							if 'tvdb' in show_col1['ids']:
-								show['ids'] = {'tvdb': show_col1['ids']['tvdb']}
-							for seasonKey in show_col1['seasons']:
-								episodes = []
-								for episodeKey in seasonKey['episodes']:
-									if watched and (episodeKey['watched'] == 1):
-										episodes.append(episodeKey)
-									elif not watched:
-										episodes.append(episodeKey)
-								if len(episodes) > 0:
-									show['seasons'].append({ 'number': seasonKey['number'], 'episodes': episodes })
-
-							if 'tvshowid' in show_col1:
-								del(show_col1['tvshowid'])
-							if self.__countEpisodes([show]) > 0:
-								shows.append(show)
-		result = { 'shows': shows}
-		return result
-
-	def __syncEpisodes(self):
-		if not self.show_progress and self.sync_on_update and self.notify and self.notify_during_playback:
-			notification('%s %s' % (utilities.getString(32045), utilities.getString(32050)), utilities.getString(32061)) #Sync started
-		if self.show_progress and not self.run_silent:
-			progress.create("%s %s" % (utilities.getString(32045), utilities.getString(32050)), line1=" ", line2=" ", line3=" ")
-
-		kodiShowsCollected, kodiShowsWatched = self.__kodiLoadShows()
-		if not isinstance(kodiShowsCollected, list) and not kodiShowsCollected:
-			logger.debug("[Episodes Sync] Kodi collected show list is empty, aborting tv show Sync.")
-			if self.show_progress and not self.run_silent:
-				progress.close()
-			return
-		if not isinstance(kodiShowsWatched, list) and not kodiShowsWatched:
-			logger.debug("[Episodes Sync] Kodi watched show list is empty, aborting tv show Sync.")
-			if self.show_progress and not self.run_silent:
-				progress.close()
-			return
-
-		traktShowsCollected, traktShowsWatched = self.__traktLoadShows()
-		if not traktShowsCollected:
-			logger.debug("[Episodes Sync] Error getting Trakt.tv collected show list, aborting tv show sync.")
-			if self.show_progress and not self.run_silent:
-				progress.close()
-			return
-		if not traktShowsWatched:
-			logger.debug("[Episodes Sync] Error getting Trakt.tv watched show list, aborting tv show sync.")
-			if self.show_progress and not self.run_silent:
-				progress.close()
-			return
-
-		#we need a correct runtime for episodes until we have that this is commented out
-		#traktShowsProgress = self.__traktLoadShowsPlaybackProgress()
-		
-		self.__addEpisodesToTraktCollection(kodiShowsCollected, traktShowsCollected)
-
-		self.__deleteEpisodesFromTraktCollection(traktShowsCollected, kodiShowsCollected)
-
-		self.__addEpisodesToTraktWatched(kodiShowsWatched, traktShowsWatched)
-
-		self.__addEpisodesToKodiWatched(traktShowsWatched, kodiShowsWatched, kodiShowsCollected)
-
-		#we need a correct runtime for episodes until we have that this is commented out
-		#self.__addEpisodeProgressToKodi(traktShowsProgress, kodiShowsCollected)
-
-		if not self.show_progress and self.sync_on_update and self.notify and self.notify_during_playback:
-			notification('%s %s' % (utilities.getString(32045), utilities.getString(32050)), utilities.getString(32062)) #Sync complete
-
-		if self.show_progress and not self.run_silent:
-			self.__updateProgress(100, line1=" ", line2=utilities.getString(32075), line3=" ")
-			progress.close()
-
-		logger.debug("[Episodes Sync] Shows on Trakt.tv (%d), shows in Kodi (%d)." % (len(traktShowsCollected['shows']), len(kodiShowsCollected['shows'])))
-
-		logger.debug("[Episodes Sync] Episodes on Trakt.tv (%d), episodes in Kodi (%d)." % (self.__countEpisodes(traktShowsCollected), self.__countEpisodes(kodiShowsCollected)))
-		logger.debug("[Episodes Sync] Complete.")
-
-	@staticmethod
-	def sanitizeShows(shows):
-		# do not remove watched_at and collected_at may cause problems between the 4 sync types (would probably have to deepcopy etc)
-		for show in shows['shows']:
-			for season in show['seasons']:
-				for episode in season['episodes']:
-					if 'collected' in episode:
-						del episode['collected']
-					if 'watched' in episode:
-						del episode['watched']
-					if 'season' in episode:
-						del episode['season']
-					if 'plays' in episode:
-						del episode['plays']
-					if 'ids' in episode and 'episodeid' in episode['ids']:
-						del episode['ids']['episodeid']
-
-	''' begin code for movie sync '''
-	def __kodiLoadMovies(self):
-		self.__updateProgress(1, line2=utilities.getString(32079))
-
-		logger.debug("[Movies Sync] Getting movie data from Kodi")
-		data = utilities.kodiJsonRequest({'jsonrpc': '2.0', 'id': 0, 'method': 'VideoLibrary.GetMovies', 'params': {'properties': ['title', 'imdbnumber', 'year', 'playcount', 'lastplayed', 'file', 'dateadded', 'runtime']}})
-		if data['limits']['total'] == 0:
-			logger.debug("[Movies Sync] Kodi JSON request was empty.")
-			return
-
-		kodi_movies = utilities.kodiRpcToTraktMediaObjects(data)
-
-		self.__updateProgress(10, line2=utilities.getString(32080))
-
-		return kodi_movies
-
-	def __traktLoadMovies(self):
-		self.__updateProgress(10, line1=utilities.getString(32079), line2=utilities.getString(32081))
-
-		logger.debug("[Movies Sync] Getting movie collection from Trakt.tv")
-
-		traktMovies = {}
-		traktMovies = self.traktapi.getMoviesCollected(traktMovies)
-
-		self.__updateProgress(17, line2=utilities.getString(32082))
-		traktMovies = self.traktapi.getMoviesWatched(traktMovies)
-		traktMovies = traktMovies.items()
-
-		self.__updateProgress(24, line2=utilities.getString(32083))
-		movies = []
-		for key, movie in traktMovies:
-			movie = movie.to_dict()
-			
-			movies.append(movie)
-
-		return movies
-
-	def __traktLoadMoviesPlaybackProgress(self):
-		if utilities.getSettingAsBool('trakt_movie_playback') and not self.__isCanceled():
-			self.__updateProgress(25, line2=utilities.getString(32122))
-
-			logger.debug('[Movies Sync] Getting playback progress from Trakt.tv')
-			try:
-				traktProgressMovies = self.traktapi.getMoviePlaybackProgress()
-			except Exception:
-				logger.debug("[Movies Sync] Invalid Trakt.tv playback progress list, possible error getting data from Trakt, aborting Trakt.tv playback update.")
-				return False
-
-			i = 0
-			x = float(len(traktProgressMovies))
-			moviesProgress = {'movies': []}
-			for movie in traktProgressMovies:
-				i += 1
-				y = ((i / x) * 25) + 11
-				self.__updateProgress(int(y), line2=utilities.getString(32123) % (i, x))
-
-				#will keep the data in python structures - just like the KODI response
-				movie = movie.to_dict()
-
-				moviesProgress['movies'].append(movie)
-
-			self.__updateProgress(36, line2=utilities.getString(32124))
-
-			return moviesProgress
-
-	def __addMoviesToTraktCollection(self, kodiMovies, traktMovies):
-		if utilities.getSettingAsBool('add_movies_to_trakt') and not self.__isCanceled():
-			addTraktMovies = copy.deepcopy(traktMovies)
-			addKodiMovies = copy.deepcopy(kodiMovies)
-
-			traktMoviesToAdd = self.__compareMovies(addKodiMovies, addTraktMovies)
-			self.sanitizeMovies(traktMoviesToAdd)
-			logger.debug("[Movies Sync] Compared movies, found %s to add." % len(traktMoviesToAdd))
-
-			if len(traktMoviesToAdd) == 0:
-				self.__updateProgress(48, line2=utilities.getString(32084))
-				logger.debug("[Movies Sync] Trakt.tv movie collection is up to date.")
-				return
-
-			titles = ", ".join(["%s" % (m['title']) for m in traktMoviesToAdd])
-			logger.debug("[Movies Sync] %i movie(s) will be added to Trakt.tv collection." % len(traktMoviesToAdd))
-			logger.debug("[Movies Sync] Movies to add : %s" % titles)
-
-			self.__updateProgress(37, line2=utilities.getString(32063) % len(traktMoviesToAdd))
-
-			moviesToAdd = {'movies': traktMoviesToAdd}
-			#logger.debug("Movies to add: %s" % moviesToAdd)
-			try:
-				self.traktapi.addToCollection(moviesToAdd)
-			except Exception as ex:
-				message = utilities.createError(ex)
-				logging.fatal(message)
-
-			self.__updateProgress(48, line2=utilities.getString(32085) % len(traktMoviesToAdd))
-
-	def __deleteMoviesFromTraktCollection(self, traktMovies, kodiMovies):
-
-		if utilities.getSettingAsBool('clean_trakt_movies') and not self.__isCanceled():
-			removeTraktMovies = copy.deepcopy(traktMovies)
-			removeKodiMovies = copy.deepcopy(kodiMovies)
-
-			logger.debug("[Movies Sync] Starting to remove.")
-			traktMoviesToRemove = self.__compareMovies(removeTraktMovies, removeKodiMovies)
-			self.sanitizeMovies(traktMoviesToRemove)
-			logger.debug("[Movies Sync] Compared movies, found %s to remove." % len(traktMoviesToRemove))
-
-			if len(traktMoviesToRemove) == 0:
-				self.__updateProgress(60, line2=utilities.getString(32091))
-				logger.debug("[Movies Sync] Trakt.tv movie collection is clean, no movies to remove.")
-				return
-
-			titles = ", ".join(["%s" % (m['title']) for m in traktMoviesToRemove])
-			logger.debug("[Movies Sync] %i movie(s) will be removed from Trakt.tv collection." % len(traktMoviesToRemove))
-			logger.debug("[Movies Sync] Movies removed: %s" % titles)
-
-			self.__updateProgress(49, line2=utilities.getString(32076) % len(traktMoviesToRemove))
-
-			moviesToRemove = {'movies': traktMoviesToRemove}
-			try:
-				self.traktapi.removeFromCollection(moviesToRemove)
-			except Exception as ex:
-				message = utilities.createError(ex)
-				logging.fatal(message)
-
-			self.__updateProgress(60, line2=utilities.getString(32092) % len(traktMoviesToRemove))
-
-
-	def __addMoviesToTraktWatched(self, kodiMovies, traktMovies):
-
-		if utilities.getSettingAsBool('trakt_movie_playcount') and not self.__isCanceled():
-			updateTraktTraktMovies = copy.deepcopy(traktMovies)
-			updateTraktKodiMovies = copy.deepcopy(kodiMovies)
-
-			traktMoviesToUpdate = self.__compareMovies(updateTraktKodiMovies, updateTraktTraktMovies, watched=True)
-			self.sanitizeMovies(traktMoviesToUpdate)
-
-			if len(traktMoviesToUpdate) == 0:
-				self.__updateProgress(72, line2=utilities.getString(32086))
-				logger.debug("[Movies Sync] Trakt.tv movie playcount is up to date")
-				return
-
-			titles = ", ".join(["%s" % (m['title']) for m in traktMoviesToUpdate])
-			logger.debug("[Movies Sync] %i movie(s) playcount will be updated on Trakt.tv" % len(traktMoviesToUpdate))
-			logger.debug("[Movies Sync] Movies updated: %s" % titles)
-
-			self.__updateProgress(61, line2=utilities.getString(32064) % len(traktMoviesToUpdate))
-			# Send request to update playcounts on Trakt.tv
-			chunksize = 200
-			chunked_movies = utilities.chunks([movie for movie in traktMoviesToUpdate], chunksize)
-			errorcount = 0
-			i = 0
-			x = float(len(traktMoviesToUpdate))
-			for chunk in chunked_movies:
-				if self.__isCanceled():
-					return
-				i += 1
-				y = ((i / x) * 11) + 61
-				self.__updateProgress(int(y), line2=utilities.getString(32093) % ((i)*chunksize if (i)*chunksize < x else x, x))
-
-				params = {'movies': chunk}
-				#logger.debug("moviechunk: %s" % params)
-				try:
-					self.traktapi.addToHistory(params)
-				except Exception as ex:
-					message = utilities.createError(ex)
-					logging.fatal(message)
-					errorcount += 1
-
-			logger.debug("[Movies Sync] Movies updated: %d error(s)" % errorcount)
-			self.__updateProgress(72, line2=utilities.getString(32087) % len(traktMoviesToUpdate))
-
-	def __addMoviesToKodiWatched(self, traktMovies, kodiMovies):
-
-		if utilities.getSettingAsBool('kodi_movie_playcount') and not self.__isCanceled():
-			updateKodiTraktMovies = copy.deepcopy(traktMovies)
-			updateKodiKodiMovies = copy.deepcopy(kodiMovies)
-
-			kodiMoviesToUpdate = self.__compareMovies(updateKodiTraktMovies, updateKodiKodiMovies, watched=True, restrict=True)
-
-			if len(kodiMoviesToUpdate) == 0:
-				self.__updateProgress(84, line2=utilities.getString(32088))
-				logger.debug("[Movies Sync] Kodi movie playcount is up to date.")
-				return
-
-			titles = ", ".join(["%s" % (m['title']) for m in kodiMoviesToUpdate])
-			logger.debug("[Movies Sync] %i movie(s) playcount will be updated in Kodi" % len(kodiMoviesToUpdate))
-			logger.debug("[Movies Sync] Movies to add: %s" % titles)
-
-			self.__updateProgress(73, line2=utilities.getString(32065) % len(kodiMoviesToUpdate))
-
-			#split movie list into chunks of 50
-			chunksize = 50
-			chunked_movies = utilities.chunks([{"jsonrpc": "2.0", "method": "VideoLibrary.SetMovieDetails", "params": {"movieid": kodiMoviesToUpdate[i]['movieid'], "playcount": kodiMoviesToUpdate[i]['plays'], "lastplayed": utilities.convertUtcToDateTime(kodiMoviesToUpdate[i]['last_watched_at'])}, "id": i} for i in range(len(kodiMoviesToUpdate))], chunksize)
-			i = 0
-			x = float(len(kodiMoviesToUpdate))
-			for chunk in chunked_movies:
-				if self.__isCanceled():
-					return
-				i += 1
-				y = ((i / x) * 11) + 73
-				self.__updateProgress(int(y), line2=utilities.getString(32089) % ((i)*chunksize if (i)*chunksize < x else x, x))
-
-				utilities.kodiJsonRequest(chunk)
-
-			self.__updateProgress(84, line2=utilities.getString(32090) % len(kodiMoviesToUpdate))
-
-	def __addMovieProgressToKodi(self, traktMovies, kodiMovies):
-
-		if utilities.getSettingAsBool('trakt_movie_playback') and traktMovies and not self.__isCanceled():
-			updateKodiTraktMovies = copy.deepcopy(traktMovies)
-			updateKodiKodiMovies = copy.deepcopy(kodiMovies)
-
-			kodiMoviesToUpdate = self.__compareMovies(updateKodiTraktMovies['movies'], updateKodiKodiMovies, restrict=True, playback=True)
-			if len(kodiMoviesToUpdate) == 0:
-				self.__updateProgress(99, line2=utilities.getString(32125))
-				logger.debug("[Movies Sync] Kodi movie playbacks are up to date.")
-				return
-
-			logger.debug("[Movies Sync] %i movie(s) playbacks will be updated in Kodi" % len(kodiMoviesToUpdate))
-
-			self.__updateProgress(85, line2=utilities.getString(32126) % len(kodiMoviesToUpdate))
-			#need to calculate the progress in int from progress in percent from Trakt
-			#split movie list into chunks of 50
-			chunksize = 50
-			chunked_movies = utilities.chunks([{"jsonrpc": "2.0", "id": i, "method": "VideoLibrary.SetMovieDetails", "params": {"movieid": kodiMoviesToUpdate[i]['movieid'], "resume": {"position": kodiMoviesToUpdate[i]['runtime']/100.0*kodiMoviesToUpdate[i]['progress']}}} for i in range(len(kodiMoviesToUpdate))], chunksize)
-			i = 0
-			x = float(len(kodiMoviesToUpdate))
-			for chunk in chunked_movies:
-				if self.__isCanceled():
-					return
-				i += 1
-				y = ((i / x) * 14) + 85
-				self.__updateProgress(int(y), line2=utilities.getString(32127) % ((i)*chunksize if (i)*chunksize < x else x, x))
-				utilities.kodiJsonRequest(chunk)
-
-			self.__updateProgress(99, line2=utilities.getString(32128) % len(kodiMoviesToUpdate))
-
-	def __syncMovies(self):
-		if not self.show_progress and self.sync_on_update and self.notify and self.notify_during_playback:
-			notification('%s %s' % (utilities.getString(32045), utilities.getString(32046)), utilities.getString(32061)) #Sync started
-		if self.show_progress and not self.run_silent:
-			progress.create("%s %s" % (utilities.getString(32045), utilities.getString(32046)), line1=" ", line2=" ", line3=" ")
-
-		kodiMovies = self.__kodiLoadMovies()
-		if not isinstance(kodiMovies, list) and not kodiMovies:
-			logger.debug("[Movies Sync] Kodi movie list is empty, aborting movie Sync.")
-			if self.show_progress and not self.run_silent:
-				progress.close()
-			return
-		try:
-			traktMovies = self.__traktLoadMovies()
-		except Exception:
-			logger.debug("[Movies Sync] Error getting Trakt.tv movie list, aborting movie Sync.")
-			if self.show_progress and not self.run_silent:
-				progress.close()
-			return
-
-		traktMoviesProgress = self.__traktLoadMoviesPlaybackProgress()
-
-		self.__addMoviesToTraktCollection(kodiMovies, traktMovies)
-
-		self.__deleteMoviesFromTraktCollection(traktMovies, kodiMovies)
-
-		self.__addMoviesToTraktWatched(kodiMovies, traktMovies)
-
-		self.__addMoviesToKodiWatched(traktMovies, kodiMovies)
-
-		self.__addMovieProgressToKodi(traktMoviesProgress, kodiMovies)
-
-		if self.show_progress and not self.run_silent:
-			self.__updateProgress(100, line1=utilities.getString(32066), line2=" ", line3=" ")
-			progress.close()
-
-		if not self.show_progress and self.sync_on_update and self.notify and self.notify_during_playback:
-			notification('%s %s' % (utilities.getString(32045), utilities.getString(32046)), utilities.getString(32062)) #Sync complete
-		
-		logger.debug("[Movies Sync] Movies on Trakt.tv (%d), movies in Kodi (%d)." % (len(traktMovies), len(kodiMovies)))
-		logger.debug("[Movies Sync] Complete.")
-
-	def __compareMovies(self, movies_col1, movies_col2, watched=False, restrict=False, playback=False):
-		movies = []
-
-		for movie_col1 in movies_col1:
-			if movie_col1:
-				movie_col2 = utilities.findMediaObject(movie_col1, movies_col2)
-				#logger.debug("movie_col1 %s" % movie_col1)
-				#logger.debug("movie_col2 %s" % movie_col2)
-
-				if movie_col2:  #match found
-					if watched: #are we looking for watched items
-						if movie_col2['watched'] == 0 and movie_col1['watched'] == 1:
-							if 'movieid' not in movie_col1:
-								movie_col1['movieid'] = movie_col2['movieid']
-							movies.append(movie_col1)
-					elif playback:
-						if 'movieid' not in movie_col1:
-								movie_col1['movieid'] = movie_col2['movieid']
-						movie_col1['runtime'] = movie_col2['runtime']
-						movies.append(movie_col1)
-					else:
-						if 'collected' in movie_col2 and not movie_col2['collected']:
-							movies.append(movie_col1)
-				else: #no match found
-					if not restrict:
-						if 'collected' in movie_col1 and movie_col1['collected']:
-							if watched and (movie_col1['watched'] == 1):
-								movies.append(movie_col1)
-							elif not watched:
-								movies.append(movie_col1)
-
-		return movies
-
-	@staticmethod
-	def sanitizeMovies(movies):
-		# do not remove watched_at and collected_at may cause problems between the 4 sync types (would probably have to deepcopy etc)
-		for movie in movies:
-			if 'collected' in movie:
-				del movie['collected']
-			if 'watched' in movie:
-				del movie['watched']
-			if 'movieid' in movie:
-				del movie['movieid']
-			if 'plays' in movie:
-				del movie['plays']
-
-	def __syncCheck(self, media_type):
-		return self.__syncCollectionCheck(media_type) or self.__syncWatchedCheck(media_type) or self.__syncPlaybackCheck(media_type)
-
-
-	def __syncPlaybackCheck(self, media_type):
-		if media_type == 'movies':
-			return utilities.getSettingAsBool('trakt_movie_playback')
-		else:
-			return False
-			#we need a correct runtime for episodes until we have that this is commented out
-			#return utilities.getSettingAsBool('trakt_episode_playback')
-
-
-	def __syncCollectionCheck(self, media_type):
-		if media_type == 'movies':
-			return utilities.getSettingAsBool('add_movies_to_trakt') or utilities.getSettingAsBool('clean_trakt_movies')
-		else:
-			return utilities.getSettingAsBool('add_episodes_to_trakt') or utilities.getSettingAsBool('clean_trakt_episodes')
-
-	def __syncWatchedCheck(self, media_type):
-		if media_type == 'movies':
-			return utilities.getSettingAsBool('trakt_movie_playcount') or utilities.getSettingAsBool('kodi_movie_playcount')
-		else:
-			return utilities.getSettingAsBool('trakt_episode_playcount') or utilities.getSettingAsBool('kodi_episode_playcount')
-
-	def sync(self):
-		logger.debug("Starting synchronization with Trakt.tv")
-
-		if self.__syncCheck('movies'):
-			if self.library in ["all", "movies"]:
-				self.__syncMovies()
-			else:
-				logger.debug("Movie sync is being skipped for this manual sync.")
-		else:
-			logger.debug("Movie sync is disabled, skipping.")
-
-		if self.__syncCheck('episodes'):
-			if self.library in ["all", "episodes"]:
-				if not (self.__syncCheck('movies') and self.__isCanceled()):
-					self.__syncEpisodes()
-				else:
-					logger.debug("Episode sync is being skipped because movie sync was canceled.")
-			else:
-				logger.debug("Episode sync is being skipped for this manual sync.")
-		else:
-			logger.debug("Episode sync is disabled, skipping.")
-
-		logger.debug("[Sync] Finished synchronization with Trakt.tv")
+    def __init__(self, show_progress=False, run_silent=False, library="all", api=None):
+        self.traktapi = api
+        self.show_progress = show_progress
+        self.run_silent = run_silent
+        self.library = library
+        if self.show_progress and self.run_silent:
+            logger.debug("Sync is being run silently.")
+        self.sync_on_update = utilities.getSettingAsBool('sync_on_update')
+        self.notify = utilities.getSettingAsBool('show_sync_notifications')
+        self.notify_during_playback = not (xbmc.Player().isPlayingVideo() and utilities.getSettingAsBool("hide_notifications_playback"))
+
+    def __isCanceled(self):
+        if self.show_progress and not self.run_silent and progress.iscanceled():
+            logger.debug("Sync was canceled by user.")
+            return True
+        elif xbmc.abortRequested:
+            logger.debug('Kodi abort requested')
+            return True
+        else:
+            return False
+
+    def __updateProgress(self, *args, **kwargs):
+        if self.show_progress and not self.run_silent:
+            kwargs['percent'] = args[0]
+            progress.update(**kwargs)
+
+    ''' begin code for episode sync '''
+    def __kodiLoadShows(self):
+        self.__updateProgress(1, line1=utilities.getString(32094), line2=utilities.getString(32095))
+
+        logger.debug("[Episodes Sync] Getting show data from Kodi")
+        data = utilities.kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetTVShows', 'params': {'properties': ['title', 'imdbnumber', 'year']}, 'id': 0})
+        if data['limits']['total'] == 0:
+            logger.debug("[Episodes Sync] Kodi json request was empty.")
+            return None, None
+
+        tvshows = utilities.kodiRpcToTraktMediaObjects(data)
+        logger.debug("[Episode Sync] Getting shows from kodi finished %s" % tvshows)
+
+        if tvshows is None:
+            return None, None
+        self.__updateProgress(2, line2=utilities.getString(32096))
+        resultCollected = {'shows': []}
+        resultWatched = {'shows': []}
+        i = 0
+        x = float(len(tvshows))
+        logger.debug("[Episodes Sync] Getting episode data from Kodi")
+        for show_col1 in tvshows:
+            i += 1
+            y = ((i / x) * 8) + 2
+            self.__updateProgress(int(y), line2=utilities.getString(32097) % (i, x))
+
+            show = {'title': show_col1['title'], 'ids': {}, 'year': show_col1['year'], 'seasons': []}
+
+            if 'ids' in show_col1 and 'tvdb' in show_col1['ids']:
+                show['ids'] = {'tvdb': show_col1['ids']['tvdb']}
+
+            data = utilities.kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetEpisodes', 'params': {'tvshowid': show_col1['tvshowid'], 'properties': ['season', 'episode', 'playcount', 'uniqueid', 'lastplayed', 'file', 'dateadded', 'runtime']}, 'id': 0})
+            if not data:
+                logger.debug("[Episodes Sync] There was a problem getting episode data for '%s', aborting sync." % show['title'])
+                return None, None
+            elif 'episodes' not in data:
+                logger.debug("[Episodes Sync] '%s' has no episodes in Kodi." % show['title'])
+                continue
+
+            if 'tvshowid' in show_col1:
+                del(show_col1['tvshowid'])
+
+            showWatched = copy.deepcopy(show)
+            data2 = copy.deepcopy(data)
+            show['seasons'] = utilities.kodiRpcToTraktMediaObjects(data)
+
+            showWatched['seasons'] = utilities.kodiRpcToTraktMediaObjects(data2, 'watched')
+
+            resultCollected['shows'].append(show)
+            resultWatched['shows'].append(showWatched)
+
+        self.__updateProgress(10, line2=utilities.getString(32098))
+        return resultCollected, resultWatched
+
+    def __traktLoadShows(self):
+        self.__updateProgress(10, line1=utilities.getString(32099), line2=utilities.getString(32100))
+
+        logger.debug('[Episodes Sync] Getting episode collection from Trakt.tv')
+        try:
+            traktShowsCollected = {}
+            traktShowsCollected = self.traktapi.getShowsCollected(traktShowsCollected)
+            traktShowsCollected = traktShowsCollected.items()
+
+            self.__updateProgress(12, line2=utilities.getString(32101))
+            traktShowsWatched = {}
+            traktShowsWatched = self.traktapi.getShowsWatched(traktShowsWatched)
+            traktShowsWatched = traktShowsWatched.items()
+        except Exception:
+            logger.debug("[Episodes Sync] Invalid Trakt.tv show list, possible error getting data from Trakt, aborting Trakt.tv collection update.")
+            return False, False
+
+        i = 0
+        x = float(len(traktShowsCollected))
+        showsCollected = {'shows': []}
+        for _, show in traktShowsCollected:
+            i += 1
+            y = ((i / x) * 20) + 6
+            self.__updateProgress(int(y), line2=utilities.getString(32102) % (i, x))
+
+            # will keep the data in python structures - just like the KODI response
+            show = show.to_dict()
+
+            showsCollected['shows'].append(show)
+
+        i = 0
+        x = float(len(traktShowsWatched))
+        showsWatched = {'shows': []}
+        for _, show in traktShowsWatched:
+            i += 1
+            y = ((i / x) * 26) + 6
+            self.__updateProgress(int(y), line2=utilities.getString(32102) % (i, x))
+
+            # will keep the data in python structures - just like the KODI response
+            show = show.to_dict()
+
+            showsWatched['shows'].append(show)
+
+        self.__updateProgress(32, line2=utilities.getString(32103))
+
+        return showsCollected, showsWatched
+
+    def __traktLoadShowsPlaybackProgress(self):
+        if utilities.getSettingAsBool('trakt_episode_playback') and not self.__isCanceled():
+            self.__updateProgress(10, line1=utilities.getString(1485), line2=utilities.getString(32119))
+
+            logger.debug('[Playback Sync] Getting playback progress from Trakt.tv')
+            try:
+                traktProgressShows = self.traktapi.getEpisodePlaybackProgress()
+            except Exception:
+                logger.debug("[Playback Sync] Invalid Trakt.tv progress list, possible error getting data from Trakt, aborting Trakt.tv playback update.")
+                return False
+
+            i = 0
+            x = float(len(traktProgressShows))
+            showsProgress = {'shows': []}
+            for show in traktProgressShows:
+                i += 1
+                y = ((i / x) * 20) + 6
+                self.__updateProgress(int(y), line2=utilities.getString(32120) % (i, x))
+
+                # will keep the data in python structures - just like the KODI response
+                show = show.to_dict()
+
+                showsProgress['shows'].append(show)
+
+            self.__updateProgress(32, line2=utilities.getString(32121))
+
+            return showsProgress
+
+    def __addEpisodesToTraktCollection(self, kodiShows, traktShows):
+        if utilities.getSettingAsBool('add_episodes_to_trakt') and not self.__isCanceled():
+            addTraktShows = copy.deepcopy(traktShows)
+            addKodiShows = copy.deepcopy(kodiShows)
+
+            tmpTraktShowsAdd = self.__compareShows(addKodiShows, addTraktShows)
+            traktShowsAdd = copy.deepcopy(tmpTraktShowsAdd)
+            self.sanitizeShows(traktShowsAdd)
+            # logger.debug("traktShowsAdd %s" % traktShowsAdd)
+
+            if len(traktShowsAdd['shows']) == 0:
+                self.__updateProgress(48, line1=utilities.getString(32068), line2=utilities.getString(32104))
+                logger.debug("[Episodes Sync] Trakt.tv episode collection is up to date.")
+                return
+            logger.debug("[Episodes Sync] %i show(s) have episodes (%d) to be added to your Trakt.tv collection." % (len(traktShowsAdd['shows']), self.__countEpisodes(traktShowsAdd)))
+            for show in traktShowsAdd['shows']:
+                logger.debug("[Episodes Sync] Episodes added: %s" % self.__getShowAsString(show, short=True))
+
+            self.__updateProgress(33, line1=utilities.getString(32068), line2=utilities.getString(32067) % (len(traktShowsAdd['shows'])), line3=" ")
+
+            # split episode list into chunks of 50
+            chunksize = 1
+            chunked_episodes = utilities.chunks(traktShowsAdd['shows'], chunksize)
+            errorcount = 0
+            i = 0
+            x = float(len(traktShowsAdd['shows']))
+            for chunk in chunked_episodes:
+                if self.__isCanceled():
+                    return
+                i += 1
+                y = ((i / x) * 16) + 33
+                self.__updateProgress(int(y), line2=utilities.getString(32069) % ((i) * chunksize if (i) * chunksize < x else x, x))
+
+                request = {'shows': chunk}
+                logger.debug("[traktAddEpisodes] Shows to add %s" % request)
+                try:
+                    self.traktapi.addToCollection(request)
+                except Exception as ex:
+                    message = utilities.createError(ex)
+                    logging.fatal(message)
+                    errorcount += 1
+
+            logger.debug("[traktAddEpisodes] Finished with %d error(s)" % errorcount)
+            self.__updateProgress(49, line2=utilities.getString(32105) % self.__countEpisodes(traktShowsAdd))
+
+    def __deleteEpisodesFromTraktCollection(self, traktShows, kodiShows):
+        if utilities.getSettingAsBool('clean_trakt_episodes') and not self.__isCanceled():
+            removeTraktShows = copy.deepcopy(traktShows)
+            removeKodiShows = copy.deepcopy(kodiShows)
+
+            traktShowsRemove = self.__compareShows(removeTraktShows, removeKodiShows)
+            self.sanitizeShows(traktShowsRemove)
+
+            if len(traktShowsRemove['shows']) == 0:
+                self.__updateProgress(65, line1=utilities.getString(32077), line2=utilities.getString(32110))
+                logger.debug('[Episodes Sync] Trakt.tv episode collection is clean, no episodes to remove.')
+                return
+
+            logger.debug("[Episodes Sync] %i show(s) will have episodes removed from Trakt.tv collection." % len(traktShowsRemove['shows']))
+            for show in traktShowsRemove['shows']:
+                logger.debug("[Episodes Sync] Episodes removed: %s" % self.__getShowAsString(show, short=True))
+
+            self.__updateProgress(50, line1=utilities.getString(32077), line2=utilities.getString(32111) % self.__countEpisodes(traktShowsRemove), line3=" ")
+
+            logger.debug("[traktRemoveEpisodes] Shows to remove %s" % traktShowsRemove)
+            try:
+                self.traktapi.removeFromCollection(traktShowsRemove)
+            except Exception as ex:
+                message = utilities.createError(ex)
+                logging.fatal(message)
+
+            self.__updateProgress(65, line2=utilities.getString(32112) % self.__countEpisodes(traktShowsRemove), line3=" ")
+
+    def __addEpisodesToTraktWatched(self, kodiShows, traktShows):
+        if utilities.getSettingAsBool('trakt_episode_playcount') and not self.__isCanceled():
+            updateTraktTraktShows = copy.deepcopy(traktShows)
+            updateTraktKodiShows = copy.deepcopy(kodiShows)
+
+            traktShowsUpdate = self.__compareShows(updateTraktKodiShows, updateTraktTraktShows, watched=True)
+            self.sanitizeShows(traktShowsUpdate)
+            # logger.debug("traktShowsUpdate %s" % traktShowsUpdate)
+
+            if len(traktShowsUpdate['shows']) == 0:
+                self.__updateProgress(82, line1=utilities.getString(32071), line2=utilities.getString(32106))
+                logger.debug("[Episodes Sync] Trakt.tv episode playcounts are up to date.")
+                return
+
+            logger.debug("[Episodes Sync] %i show(s) are missing playcounts on Trakt.tv" % len(traktShowsUpdate['shows']))
+            for show in traktShowsUpdate['shows']:
+                logger.debug("[Episodes Sync] Episodes updated: %s" % self.__getShowAsString(show, short=True))
+
+            self.__updateProgress(66, line1=utilities.getString(32071), line2=utilities.getString(32070) % (len(traktShowsUpdate['shows'])), line3="")
+            errorcount = 0
+            i = 0
+            x = float(len(traktShowsUpdate['shows']))
+            for show in traktShowsUpdate['shows']:
+                if self.__isCanceled():
+                    return
+                epCount = self.__countEpisodes([show])
+                title = show['title'].encode('utf-8', 'ignore')
+                i += 1
+                y = ((i / x) * 16) + 66
+                self.__updateProgress(int(y), line2=title, line3=utilities.getString(32073) % epCount)
+
+                s = {'shows': [show]}
+                logger.debug("[traktUpdateEpisodes] Shows to update %s" % s)
+                try:
+                    self.traktapi.addToHistory(s)
+                except Exception as ex:
+                    message = utilities.createError(ex)
+                    logging.fatal(message)
+                    errorcount += 1
+
+            logger.debug("[traktUpdateEpisodes] Finished with %d error(s)" % errorcount)
+            self.__updateProgress(82, line2=utilities.getString(32072) % (len(traktShowsUpdate['shows'])), line3="")
+
+    def __addEpisodesToKodiWatched(self, traktShows, kodiShows, kodiShowsCollected):
+        if utilities.getSettingAsBool('kodi_episode_playcount') and not self.__isCanceled():
+            updateKodiTraktShows = copy.deepcopy(traktShows)
+            updateKodiKodiShows = copy.deepcopy(kodiShows)
+
+            kodiShowsUpadate = self.__compareShows(updateKodiTraktShows, updateKodiKodiShows, watched=True, restrict=True, collected=kodiShowsCollected)
+
+            if len(kodiShowsUpadate['shows']) == 0:
+                self.__updateProgress(98, line1=utilities.getString(32074), line2=utilities.getString(32107))
+                logger.debug("[Episodes Sync] Kodi episode playcounts are up to date.")
+                return
+
+            logger.debug("[Episodes Sync] %i show(s) shows are missing playcounts on Kodi" % len(kodiShowsUpadate['shows']))
+            for s in ["%s" % self.__getShowAsString(s, short=True) for s in kodiShowsUpadate['shows']]:
+                logger.debug("[Episodes Sync] Episodes updated: %s" % s)
+
+            # logger.debug("kodiShowsUpadate: %s" % kodiShowsUpadate)
+            episodes = []
+            for show in kodiShowsUpadate['shows']:
+                for season in show['seasons']:
+                    for episode in season['episodes']:
+                        episodes.append({'episodeid': episode['ids']['episodeid'], 'playcount': episode['plays'], "lastplayed": utilities.convertUtcToDateTime(episode['last_watched_at'])})
+
+            # split episode list into chunks of 50
+            chunksize = 50
+            chunked_episodes = utilities.chunks([{"jsonrpc": "2.0", "method": "VideoLibrary.SetEpisodeDetails", "params": episodes[i], "id": i} for i in range(len(episodes))], chunksize)
+            i = 0
+            x = float(len(episodes))
+            for chunk in chunked_episodes:
+                if self.__isCanceled():
+                    return
+                i += 1
+                y = ((i / x) * 16) + 82
+                self.__updateProgress(int(y), line2=utilities.getString(32108) % ((i) * chunksize if (i) * chunksize < x else x, x))
+
+                logger.debug("[Episodes Sync] chunk %s" % str(chunk))
+                result = utilities.kodiJsonRequest(chunk)
+                logger.debug("[Episodes Sync] result %s" % str(result))
+
+            self.__updateProgress(98, line2=utilities.getString(32109) % len(episodes))
+
+    def __addEpisodeProgressToKodi(self, traktShows, kodiShows):
+        if utilities.getSettingAsBool('trakt_episode_playback') and traktShows and not self.__isCanceled():
+            updateKodiTraktShows = copy.deepcopy(traktShows)
+            updateKodiKodiShows = copy.deepcopy(kodiShows)
+            kodiShowsUpadate = self.__compareShows(updateKodiTraktShows, updateKodiKodiShows, restrict=True, playback=True)
+
+            if len(kodiShowsUpadate['shows']) == 0:
+                self.__updateProgress(98, line1=utilities.getString(1441), line2=utilities.getString(32129))
+                logger.debug("[Episodes Sync] Kodi episode playbacks are up to date.")
+                return
+
+            logger.debug("[Episodes Sync] %i show(s) shows are missing playbacks on Kodi" % len(kodiShowsUpadate['shows']))
+            for s in ["%s" % self.__getShowAsString(s, short=True) for s in kodiShowsUpadate['shows']]:
+                logger.debug("[Episodes Sync] Episodes updated: %s" % s)
+
+            episodes = []
+            for show in kodiShowsUpadate['shows']:
+                for season in show['seasons']:
+                    for episode in season['episodes']:
+                        episodes.append({'episodeid': episode['ids']['episodeid'], 'progress': episode['progress'], 'runtime': episode['runtime']})
+
+            # need to calculate the progress in int from progress in percent from Trakt
+            # split episode list into chunks of 50
+            chunksize = 50
+            chunked_episodes = utilities.chunks([{"jsonrpc": "2.0", "id": i, "method": "VideoLibrary.SetEpisodeDetails", "params": {"episodeid":episodes[i]['episodeid'], "resume": {"position": episodes[i]['runtime'] / 100.0 * episodes[i]['progress']}}} for i in range(len(episodes))], chunksize)
+            i = 0
+            x = float(len(episodes))
+            for chunk in chunked_episodes:
+                if self.__isCanceled():
+                    return
+                i += 1
+                y = ((i / x) * 16) + 82
+                self.__updateProgress(int(y), line2=utilities.getString(32130) % ((i) * chunksize if (i) * chunksize < x else x, x))
+
+                utilities.kodiJsonRequest(chunk)
+
+            self.__updateProgress(98, line2=utilities.getString(32131) % len(episodes))
+
+    def __countEpisodes(self, shows, collection=True):
+        count = 0
+        if 'shows' in shows:
+            shows = shows['shows']
+        for show in shows:
+            for seasonKey in show['seasons']:
+                if seasonKey is not None and 'episodes' in seasonKey:
+                    for episodeKey in seasonKey['episodes']:
+                        if episodeKey is not None:
+                            if 'collected' in episodeKey and not episodeKey['collected'] == collection:
+                                continue
+                            if 'number' in episodeKey and episodeKey['number']:
+                                count += 1
+        return count
+
+    def __getShowAsString(self, show, short=False):
+        p = []
+        if 'seasons' in show:
+            for season in show['seasons']:
+                s = ""
+                if short:
+                    s = ", ".join(["S%02dE%02d" % (season['number'], i['number']) for i in season['episodes']])
+                else:
+                    episodes = ", ".join([str(i) for i in show['shows']['seasons'][season]])
+                    s = "Season: %d, Episodes: %s" % (season, episodes)
+                p.append(s)
+        else:
+            p = ["All"]
+        if 'tvdb' in show['ids']:
+            return "%s [tvdb: %s] - %s" % (show['title'], show['ids']['tvdb'], ", ".join(p))
+        else:
+            return "%s [tvdb: No id] - %s" % (show['title'], ", ".join(p))
+
+    def __getEpisodes(self, seasons):
+        data = {}
+        for season in seasons:
+            episodes = {}
+            for episode in season['episodes']:
+                episodes[episode['number']] = episode
+            data[season['number']] = episodes
+
+        return data
+
+    # always return shows_col1 if you have enrich it, but don't return shows_col2
+    def __compareShows(self, shows_col1, shows_col2, watched=False, restrict=False, collected=False, playback=False):
+        shows = []
+        for show_col1 in shows_col1['shows']:
+            if show_col1:
+                show_col2 = utilities.findMediaObject(show_col1, shows_col2['shows'])
+                # logger.debug("show_col1 %s" % show_col1)
+                # logger.debug("show_col2 %s" % show_col2)
+
+                if show_col2:
+                    season_diff = {}
+                    # format the data to be easy to compare Trakt and KODI data
+                    season_col1 = self.__getEpisodes(show_col1['seasons'])
+                    season_col2 = self.__getEpisodes(show_col2['seasons'])
+                    for season in season_col1:
+                        a = season_col1[season]
+                        if season in season_col2:
+                            b = season_col2[season]
+                            diff = list(set(a).difference(set(b)))
+                            if playback:
+                                t = list(set(a).intersection(set(b)))
+                                if len(t) > 0:
+                                    eps = {}
+                                    for ep in t:
+                                        eps[ep] = a[ep]
+                                        if 'episodeid' in season_col2[season][ep]['ids']:
+                                            if 'ids' in eps:
+                                                eps[ep]['ids']['episodeid'] = season_col2[season][ep]['ids']['episodeid']
+                                            else:
+                                                eps[ep]['ids'] = {'episodeid': season_col2[season][ep]['ids']['episodeid']}
+                                        eps[ep]['runtime'] = season_col2[season][ep]['runtime']
+                                    season_diff[season] = eps
+                            elif len(diff) > 0:
+                                if restrict:
+                                    # get all the episodes that we have in Kodi, watched or not - update kodi
+                                    collectedShow = utilities.findMediaObject(show_col1, collected['shows'])
+                                    # logger.debug("collected %s" % collectedShow)
+                                    collectedSeasons = self.__getEpisodes(collectedShow['seasons'])
+                                    t = list(set(collectedSeasons[season]).intersection(set(diff)))
+                                    if len(t) > 0:
+                                        eps = {}
+                                        for ep in t:
+                                            eps[ep] = a[ep]
+                                            if 'episodeid' in collectedSeasons[season][ep]['ids']:
+                                                if 'ids' in eps:
+                                                    eps[ep]['ids']['episodeid'] = collectedSeasons[season][ep]['ids']['episodeid']
+                                                else:
+                                                    eps[ep]['ids'] = {'episodeid': collectedSeasons[season][ep]['ids']['episodeid']}
+                                        season_diff[season] = eps
+                                else:
+                                    eps = {}
+                                    for ep in diff:
+                                        eps[ep] = a[ep]
+                                    if len(eps) > 0:
+                                        season_diff[season] = eps
+                        else:
+                            if not restrict:
+                                if len(a) > 0:
+                                    season_diff[season] = a
+                    # logger.debug("season_diff %s" % season_diff)
+                    if len(season_diff) > 0:
+                        # logger.debug("Season_diff")
+                        show = {'title': show_col1['title'], 'ids': {}, 'year': show_col1['year'], 'seasons': []}
+                        if 'tvdb' in show_col1['ids']:
+                            show['ids'] = {'tvdb': show_col1['ids']['tvdb']}
+                        for seasonKey in season_diff:
+                            episodes = []
+                            for episodeKey in season_diff[seasonKey]:
+                                episodes.append(season_diff[seasonKey][episodeKey])
+                            show['seasons'].append({'number': seasonKey, 'episodes': episodes})
+                        if 'imdb' in show_col2 and show_col2['imdb']:
+                            show['ids']['imdb'] = show_col2['imdb']
+                        if 'tvshowid' in show_col2:
+                            show['tvshowid'] = show_col2['tvshowid']
+                        # logger.debug("show %s" % show)
+                        shows.append(show)
+                else:
+                    if not restrict:
+                        if self.__countEpisodes([show_col1]) > 0:
+                            show = {'title': show_col1['title'], 'ids': {}, 'year': show_col1['year'], 'seasons': []}
+                            if 'tvdb' in show_col1['ids']:
+                                show['ids'] = {'tvdb': show_col1['ids']['tvdb']}
+                            for seasonKey in show_col1['seasons']:
+                                episodes = []
+                                for episodeKey in seasonKey['episodes']:
+                                    if watched and (episodeKey['watched'] == 1):
+                                        episodes.append(episodeKey)
+                                    elif not watched:
+                                        episodes.append(episodeKey)
+                                if len(episodes) > 0:
+                                    show['seasons'].append({'number': seasonKey['number'], 'episodes': episodes})
+
+                            if 'tvshowid' in show_col1:
+                                del(show_col1['tvshowid'])
+                            if self.__countEpisodes([show]) > 0:
+                                shows.append(show)
+        result = {'shows': shows}
+        return result
+
+    def __syncEpisodes(self):
+        if not self.show_progress and self.sync_on_update and self.notify and self.notify_during_playback:
+            notification('%s %s' % (utilities.getString(32045), utilities.getString(32050)), utilities.getString(32061))  # Sync started
+        if self.show_progress and not self.run_silent:
+            progress.create("%s %s" % (utilities.getString(32045), utilities.getString(32050)), line1=" ", line2=" ", line3=" ")
+
+        kodiShowsCollected, kodiShowsWatched = self.__kodiLoadShows()
+        if not isinstance(kodiShowsCollected, list) and not kodiShowsCollected:
+            logger.debug("[Episodes Sync] Kodi collected show list is empty, aborting tv show Sync.")
+            if self.show_progress and not self.run_silent:
+                progress.close()
+            return
+        if not isinstance(kodiShowsWatched, list) and not kodiShowsWatched:
+            logger.debug("[Episodes Sync] Kodi watched show list is empty, aborting tv show Sync.")
+            if self.show_progress and not self.run_silent:
+                progress.close()
+            return
+
+        traktShowsCollected, traktShowsWatched = self.__traktLoadShows()
+        if not traktShowsCollected:
+            logger.debug("[Episodes Sync] Error getting Trakt.tv collected show list, aborting tv show sync.")
+            if self.show_progress and not self.run_silent:
+                progress.close()
+            return
+        if not traktShowsWatched:
+            logger.debug("[Episodes Sync] Error getting Trakt.tv watched show list, aborting tv show sync.")
+            if self.show_progress and not self.run_silent:
+                progress.close()
+            return
+
+        # we need a correct runtime for episodes until we have that this is commented out
+        # traktShowsProgress = self.__traktLoadShowsPlaybackProgress()
+
+        self.__addEpisodesToTraktCollection(kodiShowsCollected, traktShowsCollected)
+
+        self.__deleteEpisodesFromTraktCollection(traktShowsCollected, kodiShowsCollected)
+
+        self.__addEpisodesToTraktWatched(kodiShowsWatched, traktShowsWatched)
+
+        self.__addEpisodesToKodiWatched(traktShowsWatched, kodiShowsWatched, kodiShowsCollected)
+
+        # we need a correct runtime for episodes until we have that this is commented out
+        # self.__addEpisodeProgressToKodi(traktShowsProgress, kodiShowsCollected)
+
+        if not self.show_progress and self.sync_on_update and self.notify and self.notify_during_playback:
+            notification('%s %s' % (utilities.getString(32045), utilities.getString(32050)), utilities.getString(32062))  # Sync complete
+
+        if self.show_progress and not self.run_silent:
+            self.__updateProgress(100, line1=" ", line2=utilities.getString(32075), line3=" ")
+            progress.close()
+
+        logger.debug("[Episodes Sync] Shows on Trakt.tv (%d), shows in Kodi (%d)." % (len(traktShowsCollected['shows']), len(kodiShowsCollected['shows'])))
+
+        logger.debug("[Episodes Sync] Episodes on Trakt.tv (%d), episodes in Kodi (%d)." % (self.__countEpisodes(traktShowsCollected), self.__countEpisodes(kodiShowsCollected)))
+        logger.debug("[Episodes Sync] Complete.")
+
+    @staticmethod
+    def sanitizeShows(shows):
+        # do not remove watched_at and collected_at may cause problems between the 4 sync types (would probably have to deepcopy etc)
+        for show in shows['shows']:
+            for season in show['seasons']:
+                for episode in season['episodes']:
+                    if 'collected' in episode:
+                        del episode['collected']
+                    if 'watched' in episode:
+                        del episode['watched']
+                    if 'season' in episode:
+                        del episode['season']
+                    if 'plays' in episode:
+                        del episode['plays']
+                    if 'ids' in episode and 'episodeid' in episode['ids']:
+                        del episode['ids']['episodeid']
+
+    ''' begin code for movie sync '''
+    def __kodiLoadMovies(self):
+        self.__updateProgress(1, line2=utilities.getString(32079))
+
+        logger.debug("[Movies Sync] Getting movie data from Kodi")
+        data = utilities.kodiJsonRequest({'jsonrpc': '2.0', 'id': 0, 'method': 'VideoLibrary.GetMovies', 'params': {'properties': ['title', 'imdbnumber', 'year', 'playcount', 'lastplayed', 'file', 'dateadded', 'runtime']}})
+        if data['limits']['total'] == 0:
+            logger.debug("[Movies Sync] Kodi JSON request was empty.")
+            return
+
+        kodi_movies = utilities.kodiRpcToTraktMediaObjects(data)
+
+        self.__updateProgress(10, line2=utilities.getString(32080))
+
+        return kodi_movies
+
+    def __traktLoadMovies(self):
+        self.__updateProgress(10, line1=utilities.getString(32079), line2=utilities.getString(32081))
+
+        logger.debug("[Movies Sync] Getting movie collection from Trakt.tv")
+
+        traktMovies = {}
+        traktMovies = self.traktapi.getMoviesCollected(traktMovies)
+
+        self.__updateProgress(17, line2=utilities.getString(32082))
+        traktMovies = self.traktapi.getMoviesWatched(traktMovies)
+        traktMovies = traktMovies.items()
+
+        self.__updateProgress(24, line2=utilities.getString(32083))
+        movies = []
+        for _, movie in traktMovies:
+            movie = movie.to_dict()
+
+            movies.append(movie)
+
+        return movies
+
+    def __traktLoadMoviesPlaybackProgress(self):
+        if utilities.getSettingAsBool('trakt_movie_playback') and not self.__isCanceled():
+            self.__updateProgress(25, line2=utilities.getString(32122))
+
+            logger.debug('[Movies Sync] Getting playback progress from Trakt.tv')
+            try:
+                traktProgressMovies = self.traktapi.getMoviePlaybackProgress()
+            except Exception:
+                logger.debug("[Movies Sync] Invalid Trakt.tv playback progress list, possible error getting data from Trakt, aborting Trakt.tv playback update.")
+                return False
+
+            i = 0
+            x = float(len(traktProgressMovies))
+            moviesProgress = {'movies': []}
+            for movie in traktProgressMovies:
+                i += 1
+                y = ((i / x) * 25) + 11
+                self.__updateProgress(int(y), line2=utilities.getString(32123) % (i, x))
+
+                # will keep the data in python structures - just like the KODI response
+                movie = movie.to_dict()
+
+                moviesProgress['movies'].append(movie)
+
+            self.__updateProgress(36, line2=utilities.getString(32124))
+
+            return moviesProgress
+
+    def __addMoviesToTraktCollection(self, kodiMovies, traktMovies):
+        if utilities.getSettingAsBool('add_movies_to_trakt') and not self.__isCanceled():
+            addTraktMovies = copy.deepcopy(traktMovies)
+            addKodiMovies = copy.deepcopy(kodiMovies)
+
+            traktMoviesToAdd = self.__compareMovies(addKodiMovies, addTraktMovies)
+            self.sanitizeMovies(traktMoviesToAdd)
+            logger.debug("[Movies Sync] Compared movies, found %s to add." % len(traktMoviesToAdd))
+
+            if len(traktMoviesToAdd) == 0:
+                self.__updateProgress(48, line2=utilities.getString(32084))
+                logger.debug("[Movies Sync] Trakt.tv movie collection is up to date.")
+                return
+
+            titles = ", ".join(["%s" % (m['title']) for m in traktMoviesToAdd])
+            logger.debug("[Movies Sync] %i movie(s) will be added to Trakt.tv collection." % len(traktMoviesToAdd))
+            logger.debug("[Movies Sync] Movies to add : %s" % titles)
+
+            self.__updateProgress(37, line2=utilities.getString(32063) % len(traktMoviesToAdd))
+
+            moviesToAdd = {'movies': traktMoviesToAdd}
+            # logger.debug("Movies to add: %s" % moviesToAdd)
+            try:
+                self.traktapi.addToCollection(moviesToAdd)
+            except Exception as ex:
+                message = utilities.createError(ex)
+                logging.fatal(message)
+
+            self.__updateProgress(48, line2=utilities.getString(32085) % len(traktMoviesToAdd))
+
+    def __deleteMoviesFromTraktCollection(self, traktMovies, kodiMovies):
+
+        if utilities.getSettingAsBool('clean_trakt_movies') and not self.__isCanceled():
+            removeTraktMovies = copy.deepcopy(traktMovies)
+            removeKodiMovies = copy.deepcopy(kodiMovies)
+
+            logger.debug("[Movies Sync] Starting to remove.")
+            traktMoviesToRemove = self.__compareMovies(removeTraktMovies, removeKodiMovies)
+            self.sanitizeMovies(traktMoviesToRemove)
+            logger.debug("[Movies Sync] Compared movies, found %s to remove." % len(traktMoviesToRemove))
+
+            if len(traktMoviesToRemove) == 0:
+                self.__updateProgress(60, line2=utilities.getString(32091))
+                logger.debug("[Movies Sync] Trakt.tv movie collection is clean, no movies to remove.")
+                return
+
+            titles = ", ".join(["%s" % (m['title']) for m in traktMoviesToRemove])
+            logger.debug("[Movies Sync] %i movie(s) will be removed from Trakt.tv collection." % len(traktMoviesToRemove))
+            logger.debug("[Movies Sync] Movies removed: %s" % titles)
+
+            self.__updateProgress(49, line2=utilities.getString(32076) % len(traktMoviesToRemove))
+
+            moviesToRemove = {'movies': traktMoviesToRemove}
+            try:
+                self.traktapi.removeFromCollection(moviesToRemove)
+            except Exception as ex:
+                message = utilities.createError(ex)
+                logging.fatal(message)
+
+            self.__updateProgress(60, line2=utilities.getString(32092) % len(traktMoviesToRemove))
+
+    def __addMoviesToTraktWatched(self, kodiMovies, traktMovies):
+        if utilities.getSettingAsBool('trakt_movie_playcount') and not self.__isCanceled():
+            updateTraktTraktMovies = copy.deepcopy(traktMovies)
+            updateTraktKodiMovies = copy.deepcopy(kodiMovies)
+
+            traktMoviesToUpdate = self.__compareMovies(updateTraktKodiMovies, updateTraktTraktMovies, watched=True)
+            self.sanitizeMovies(traktMoviesToUpdate)
+
+            if len(traktMoviesToUpdate) == 0:
+                self.__updateProgress(72, line2=utilities.getString(32086))
+                logger.debug("[Movies Sync] Trakt.tv movie playcount is up to date")
+                return
+
+            titles = ", ".join(["%s" % (m['title']) for m in traktMoviesToUpdate])
+            logger.debug("[Movies Sync] %i movie(s) playcount will be updated on Trakt.tv" % len(traktMoviesToUpdate))
+            logger.debug("[Movies Sync] Movies updated: %s" % titles)
+
+            self.__updateProgress(61, line2=utilities.getString(32064) % len(traktMoviesToUpdate))
+            # Send request to update playcounts on Trakt.tv
+            chunksize = 200
+            chunked_movies = utilities.chunks([movie for movie in traktMoviesToUpdate], chunksize)
+            errorcount = 0
+            i = 0
+            x = float(len(traktMoviesToUpdate))
+            for chunk in chunked_movies:
+                if self.__isCanceled():
+                    return
+                i += 1
+                y = ((i / x) * 11) + 61
+                self.__updateProgress(int(y), line2=utilities.getString(32093) % ((i) * chunksize if (i) * chunksize < x else x, x))
+
+                params = {'movies': chunk}
+                # logger.debug("moviechunk: %s" % params)
+                try:
+                    self.traktapi.addToHistory(params)
+                except Exception as ex:
+                    message = utilities.createError(ex)
+                    logging.fatal(message)
+                    errorcount += 1
+
+            logger.debug("[Movies Sync] Movies updated: %d error(s)" % errorcount)
+            self.__updateProgress(72, line2=utilities.getString(32087) % len(traktMoviesToUpdate))
+
+    def __addMoviesToKodiWatched(self, traktMovies, kodiMovies):
+
+        if utilities.getSettingAsBool('kodi_movie_playcount') and not self.__isCanceled():
+            updateKodiTraktMovies = copy.deepcopy(traktMovies)
+            updateKodiKodiMovies = copy.deepcopy(kodiMovies)
+
+            kodiMoviesToUpdate = self.__compareMovies(updateKodiTraktMovies, updateKodiKodiMovies, watched=True, restrict=True)
+
+            if len(kodiMoviesToUpdate) == 0:
+                self.__updateProgress(84, line2=utilities.getString(32088))
+                logger.debug("[Movies Sync] Kodi movie playcount is up to date.")
+                return
+
+            titles = ", ".join(["%s" % (m['title']) for m in kodiMoviesToUpdate])
+            logger.debug("[Movies Sync] %i movie(s) playcount will be updated in Kodi" % len(kodiMoviesToUpdate))
+            logger.debug("[Movies Sync] Movies to add: %s" % titles)
+
+            self.__updateProgress(73, line2=utilities.getString(32065) % len(kodiMoviesToUpdate))
+
+            # split movie list into chunks of 50
+            chunksize = 50
+            chunked_movies = utilities.chunks([{"jsonrpc": "2.0", "method": "VideoLibrary.SetMovieDetails", "params": {"movieid": kodiMoviesToUpdate[i]['movieid'], "playcount": kodiMoviesToUpdate[i]['plays'], "lastplayed": utilities.convertUtcToDateTime(kodiMoviesToUpdate[i]['last_watched_at'])}, "id": i} for i in range(len(kodiMoviesToUpdate))], chunksize)
+            i = 0
+            x = float(len(kodiMoviesToUpdate))
+            for chunk in chunked_movies:
+                if self.__isCanceled():
+                    return
+                i += 1
+                y = ((i / x) * 11) + 73
+                self.__updateProgress(int(y), line2=utilities.getString(32089) % ((i) * chunksize if (i) * chunksize < x else x, x))
+
+                utilities.kodiJsonRequest(chunk)
+
+            self.__updateProgress(84, line2=utilities.getString(32090) % len(kodiMoviesToUpdate))
+
+    def __addMovieProgressToKodi(self, traktMovies, kodiMovies):
+
+        if utilities.getSettingAsBool('trakt_movie_playback') and traktMovies and not self.__isCanceled():
+            updateKodiTraktMovies = copy.deepcopy(traktMovies)
+            updateKodiKodiMovies = copy.deepcopy(kodiMovies)
+
+            kodiMoviesToUpdate = self.__compareMovies(updateKodiTraktMovies['movies'], updateKodiKodiMovies, restrict=True, playback=True)
+            if len(kodiMoviesToUpdate) == 0:
+                self.__updateProgress(99, line2=utilities.getString(32125))
+                logger.debug("[Movies Sync] Kodi movie playbacks are up to date.")
+                return
+
+            logger.debug("[Movies Sync] %i movie(s) playbacks will be updated in Kodi" % len(kodiMoviesToUpdate))
+
+            self.__updateProgress(85, line2=utilities.getString(32126) % len(kodiMoviesToUpdate))
+            # need to calculate the progress in int from progress in percent from Trakt
+            # split movie list into chunks of 50
+            chunksize = 50
+            chunked_movies = utilities.chunks([{"jsonrpc": "2.0", "id": i, "method": "VideoLibrary.SetMovieDetails", "params": {"movieid": kodiMoviesToUpdate[i]['movieid'], "resume": {"position": kodiMoviesToUpdate[i]['runtime'] / 100.0 * kodiMoviesToUpdate[i]['progress']}}} for i in range(len(kodiMoviesToUpdate))], chunksize)
+            i = 0
+            x = float(len(kodiMoviesToUpdate))
+            for chunk in chunked_movies:
+                if self.__isCanceled():
+                    return
+                i += 1
+                y = ((i / x) * 14) + 85
+                self.__updateProgress(int(y), line2=utilities.getString(32127) % ((i) * chunksize if (i) * chunksize < x else x, x))
+                utilities.kodiJsonRequest(chunk)
+
+            self.__updateProgress(99, line2=utilities.getString(32128) % len(kodiMoviesToUpdate))
+
+    def __syncMovies(self):
+        if not self.show_progress and self.sync_on_update and self.notify and self.notify_during_playback:
+            notification('%s %s' % (utilities.getString(32045), utilities.getString(32046)), utilities.getString(32061))  # Sync started
+        if self.show_progress and not self.run_silent:
+            progress.create("%s %s" % (utilities.getString(32045), utilities.getString(32046)), line1=" ", line2=" ", line3=" ")
+
+        kodiMovies = self.__kodiLoadMovies()
+        if not isinstance(kodiMovies, list) and not kodiMovies:
+            logger.debug("[Movies Sync] Kodi movie list is empty, aborting movie Sync.")
+            if self.show_progress and not self.run_silent:
+                progress.close()
+            return
+        try:
+            traktMovies = self.__traktLoadMovies()
+        except Exception:
+            logger.debug("[Movies Sync] Error getting Trakt.tv movie list, aborting movie Sync.")
+            if self.show_progress and not self.run_silent:
+                progress.close()
+            return
+
+        traktMoviesProgress = self.__traktLoadMoviesPlaybackProgress()
+
+        self.__addMoviesToTraktCollection(kodiMovies, traktMovies)
+
+        self.__deleteMoviesFromTraktCollection(traktMovies, kodiMovies)
+
+        self.__addMoviesToTraktWatched(kodiMovies, traktMovies)
+
+        self.__addMoviesToKodiWatched(traktMovies, kodiMovies)
+
+        self.__addMovieProgressToKodi(traktMoviesProgress, kodiMovies)
+
+        if self.show_progress and not self.run_silent:
+            self.__updateProgress(100, line1=utilities.getString(32066), line2=" ", line3=" ")
+            progress.close()
+
+        if not self.show_progress and self.sync_on_update and self.notify and self.notify_during_playback:
+            notification('%s %s' % (utilities.getString(32045), utilities.getString(32046)), utilities.getString(32062))  # Sync complete
+
+        logger.debug("[Movies Sync] Movies on Trakt.tv (%d), movies in Kodi (%d)." % (len(traktMovies), len(kodiMovies)))
+        logger.debug("[Movies Sync] Complete.")
+
+    def __compareMovies(self, movies_col1, movies_col2, watched=False, restrict=False, playback=False):
+        movies = []
+
+        for movie_col1 in movies_col1:
+            if movie_col1:
+                movie_col2 = utilities.findMediaObject(movie_col1, movies_col2)
+                # logger.debug("movie_col1 %s" % movie_col1)
+                # logger.debug("movie_col2 %s" % movie_col2)
+
+                if movie_col2:  # match found
+                    if watched:  # are we looking for watched items
+                        if movie_col2['watched'] == 0 and movie_col1['watched'] == 1:
+                            if 'movieid' not in movie_col1:
+                                movie_col1['movieid'] = movie_col2['movieid']
+                            movies.append(movie_col1)
+                    elif playback:
+                        if 'movieid' not in movie_col1:
+                                movie_col1['movieid'] = movie_col2['movieid']
+                        movie_col1['runtime'] = movie_col2['runtime']
+                        movies.append(movie_col1)
+                    else:
+                        if 'collected' in movie_col2 and not movie_col2['collected']:
+                            movies.append(movie_col1)
+                else:  # no match found
+                    if not restrict:
+                        if 'collected' in movie_col1 and movie_col1['collected']:
+                            if watched and (movie_col1['watched'] == 1):
+                                movies.append(movie_col1)
+                            elif not watched:
+                                movies.append(movie_col1)
+
+        return movies
+
+    @staticmethod
+    def sanitizeMovies(movies):
+        # do not remove watched_at and collected_at may cause problems between the 4 sync types (would probably have to deepcopy etc)
+        for movie in movies:
+            if 'collected' in movie:
+                del movie['collected']
+            if 'watched' in movie:
+                del movie['watched']
+            if 'movieid' in movie:
+                del movie['movieid']
+            if 'plays' in movie:
+                del movie['plays']
+
+    def __syncCheck(self, media_type):
+        return self.__syncCollectionCheck(media_type) or self.__syncWatchedCheck(media_type) or self.__syncPlaybackCheck(media_type)
+
+    def __syncPlaybackCheck(self, media_type):
+        if media_type == 'movies':
+            return utilities.getSettingAsBool('trakt_movie_playback')
+        else:
+            return False
+            # we need a correct runtime for episodes until we have that this is commented out
+            # return utilities.getSettingAsBool('trakt_episode_playback')
+
+    def __syncCollectionCheck(self, media_type):
+        if media_type == 'movies':
+            return utilities.getSettingAsBool('add_movies_to_trakt') or utilities.getSettingAsBool('clean_trakt_movies')
+        else:
+            return utilities.getSettingAsBool('add_episodes_to_trakt') or utilities.getSettingAsBool('clean_trakt_episodes')
+
+    def __syncWatchedCheck(self, media_type):
+        if media_type == 'movies':
+            return utilities.getSettingAsBool('trakt_movie_playcount') or utilities.getSettingAsBool('kodi_movie_playcount')
+        else:
+            return utilities.getSettingAsBool('trakt_episode_playcount') or utilities.getSettingAsBool('kodi_episode_playcount')
+
+    def sync(self):
+        logger.debug("Starting synchronization with Trakt.tv")
+
+        if self.__syncCheck('movies'):
+            if self.library in ["all", "movies"]:
+                self.__syncMovies()
+            else:
+                logger.debug("Movie sync is being skipped for this manual sync.")
+        else:
+            logger.debug("Movie sync is disabled, skipping.")
+
+        if self.__syncCheck('episodes'):
+            if self.library in ["all", "episodes"]:
+                if not (self.__syncCheck('movies') and self.__isCanceled()):
+                    self.__syncEpisodes()
+                else:
+                    logger.debug("Episode sync is being skipped because movie sync was canceled.")
+            else:
+                logger.debug("Episode sync is being skipped for this manual sync.")
+        else:
+            logger.debug("Episode sync is disabled, skipping.")
+
+        logger.debug("[Sync] Finished synchronization with Trakt.tv")

--- a/traktContextMenu.py
+++ b/traktContextMenu.py
@@ -19,65 +19,65 @@ ACTION_ITEM_SELECT = [ACTION_SELECT_ITEM, ACTION_MOUSE_LEFT_CLICK]
 
 
 class traktContextMenu(xbmcgui.WindowXMLDialog):
-	action = None
+    action = None
 
-	def __new__(cls, media_type=None, buttons=None):
-		return super(traktContextMenu, cls).__new__(cls, "traktContextMenu.xml", __addon__.getAddonInfo('path'),
-													media_type=media_type, buttons=None)
+    def __new__(cls, media_type=None, buttons=None):
+        return super(traktContextMenu, cls).__new__(cls, "traktContextMenu.xml", __addon__.getAddonInfo('path'),
+                                                    media_type=media_type, buttons=None)
 
-	def __init__(self, *args, **kwargs):
-		self.buttons = kwargs['buttons']
-		self.media_type = kwargs['media_type']
-		super(traktContextMenu, self).__init__()
+    def __init__(self, *args, **kwargs):
+        self.buttons = kwargs['buttons']
+        self.media_type = kwargs['media_type']
+        super(traktContextMenu, self).__init__()
 
-	def onInit(self):
-		lang = utils.getString
-		mange_string = lang(32133) if utils.isMovie(self.media_type) else lang(32134)
-		rate_string = lang(32137)
-		if utils.isShow(self.media_type):
-			rate_string = lang(32138)
-		elif utils.isEpisode(self.media_type):
-			rate_string = lang(32139)
+    def onInit(self):
+        lang = utils.getString
+        mange_string = lang(32133) if utils.isMovie(self.media_type) else lang(32134)
+        rate_string = lang(32137)
+        if utils.isShow(self.media_type):
+            rate_string = lang(32138)
+        elif utils.isEpisode(self.media_type):
+            rate_string = lang(32139)
 
-		actions = [mange_string, lang(32135), lang(32136), rate_string, lang(32140), lang(32141), lang(32142), lang(32143)]
-		keys = ["itemlists", "removefromlist", "addtolist", "rate", "togglewatched", "managelists", "updatetags",
-				"sync"]
+        actions = [mange_string, lang(32135), lang(32136), rate_string, lang(32140), lang(32141), lang(32142), lang(32143)]
+        keys = ["itemlists", "removefromlist", "addtolist", "rate", "togglewatched", "managelists", "updatetags",
+                "sync"]
 
-		l = self.getControl(ACTION_LIST)
-		for i in range(len(actions)):
-			if keys[i] in self.buttons:
-				l.addItem(self.newListItem(actions[i], id=keys[i]))
+        l = self.getControl(ACTION_LIST)
+        for i in range(len(actions)):
+            if keys[i] in self.buttons:
+                l.addItem(self.newListItem(actions[i], id=keys[i]))
 
-		h = ((len(self.buttons)) * 46) - 6
-		l.setHeight(h)
+        h = ((len(self.buttons)) * 46) - 6
+        l.setHeight(h)
 
-		d = self.getControl(DIALOG_IMAGE)
-		d.setHeight(h + 40)
+        d = self.getControl(DIALOG_IMAGE)
+        d.setHeight(h + 40)
 
-		offset = (316 - h) / 2
+        offset = (316 - h) / 2
 
-		d.setPosition(0, offset - 20)
-		l.setPosition(20, offset)
+        d.setPosition(0, offset - 20)
+        l.setPosition(20, offset)
 
-		self.setFocus(l)
+        self.setFocus(l)
 
-	def newListItem(self, label, selected=False, *args, **kwargs):
-		item = xbmcgui.ListItem(label)
-		item.select(selected)
-		for key in kwargs:
-			item.setProperty(key, str(kwargs[key]))
-		return item
+    def newListItem(self, label, selected=False, *args, **kwargs):
+        item = xbmcgui.ListItem(label)
+        item.select(selected)
+        for key in kwargs:
+            item.setProperty(key, str(kwargs[key]))
+        return item
 
-	def onAction(self, action):
-		if not action.getId() in ACTION_ITEM_SELECT:
-			if action in ACTION_CLOSE_LIST:
-				self.close()
+    def onAction(self, action):
+        if not action.getId() in ACTION_ITEM_SELECT:
+            if action in ACTION_CLOSE_LIST:
+                self.close()
 
-		if action in ACTION_ITEM_SELECT:
-			cID = self.getFocusId()
-			if cID == ACTION_LIST:
-				l = self.getControl(cID)
-				item = l.getSelectedItem()
-				selected = not item.isSelected()
-				self.action = item.getProperty('id')
-				self.close()
+        if action in ACTION_ITEM_SELECT:
+            cID = self.getFocusId()
+            if cID == ACTION_LIST:
+                l = self.getControl(cID)
+                item = l.getSelectedItem()
+                selected = not item.isSelected()
+                self.action = item.getProperty('id')
+                self.close()

--- a/traktapi.py
+++ b/traktapi.py
@@ -13,237 +13,234 @@ __addonversion__ = __addon__.getAddonInfo('version')
 logger = logging.getLogger(__name__)
 
 class traktAPI(object):
-	__apikey = "d4161a7a106424551add171e5470112e4afdaf2438e6ef2fe0548edc75924868"
-	__token = ""
-	__username = ""
-	__password = ""
+    __apikey = "d4161a7a106424551add171e5470112e4afdaf2438e6ef2fe0548edc75924868"
+    __token = ""
+    __username = ""
+    __password = ""
 
-	def __init__(self):
-		logger.debug("Initializing.")
+    def __init__(self):
+        logger.debug("Initializing.")
 
-		# Get user login data
-		self.__username = getSetting('username')
-		self.__password = getSetting('password')
+        # Get user login data
+        self.__username = getSetting('username')
+        self.__password = getSetting('password')
 
-		# Configure
-		Trakt.configuration.defaults.client(
-			id=self.__apikey
-		)
+        # Configure
+        Trakt.configuration.defaults.client(
+            id=self.__apikey
+        )
 
-		if not self.__token:
-			self.getToken()
+        if not self.__token:
+            self.getToken()
 
-	# helper for onSettingsChanged
-	def updateSettings(self):
+    # helper for onSettingsChanged
+    def updateSettings(self):
 
-		_username = getSetting('username')
-		_password = getSetting('password')
+        _username = getSetting('username')
+        _password = getSetting('password')
 
-		updated = False
-		if self.__username != _username:
-			self.__username = _username
-			updated = True
+        updated = False
+        if self.__username != _username:
+            self.__username = _username
+            updated = True
 
-		if self.__password != _password:
-			self.__password = _password
-			updated = True
+        if self.__password != _password:
+            self.__password = _password
+            updated = True
 
-		if updated:
-			self.getToken()
+        if updated:
+            self.getToken()
 
-	def getToken(self):
-		if not self.__username and not self.__password:
-			notification('Trakt', getString(32021)) #Username and password error
-		elif not self.__password:
-			notification('Trakt', getString(32022)) #Password error
-		else:
-			# Attempt authentication (retrieve new token)
-			with Trakt.configuration.http(retry=True):
-				try:
-					auth = Trakt['auth'].login(getSetting('username'), getSetting('password'))
-					if auth:
-						self.__token = auth
-					else:
-						logger.debug("Authentication Failure")
-						notification('Trakt', getString(32025))
-				except Exception as ex:
-					message = createError(ex)
-					logger.fatal(message)
-					logger.debug("Cannot connect to server")
-					notification('Trakt', getString(32023))
+    def getToken(self):
+        if not self.__username and not self.__password:
+            notification('Trakt', getString(32021))  # Username and password error
+        elif not self.__password:
+            notification('Trakt', getString(32022))  # Password error
+        else:
+            # Attempt authentication (retrieve new token)
+            with Trakt.configuration.http(retry=True):
+                try:
+                    auth = Trakt['auth'].login(getSetting('username'), getSetting('password'))
+                    if auth:
+                        self.__token = auth
+                    else:
+                        logger.debug("Authentication Failure")
+                        notification('Trakt', getString(32025))
+                except Exception as ex:
+                    message = createError(ex)
+                    logger.fatal(message)
+                    logger.debug("Cannot connect to server")
+                    notification('Trakt', getString(32023))
 
+    def scrobbleEpisode(self, show, episode, percent, status):
+        result = None
 
+        with Trakt.configuration.auth(self.__username, self.__token):
+            if status == 'start':
+                with Trakt.configuration.http(retry=True):
+                    result = Trakt['scrobble'].start(
+                        show=show,
+                        episode=episode,
+                        progress=percent)
+            elif status == 'pause':
+                with Trakt.configuration.http(retry=True):
+                    result = Trakt['scrobble'].pause(
+                        show=show,
+                        episode=episode,
+                        progress=percent)
+            elif status == 'stop':
+                #don't retry on stop, this will cause multiple scrobbles
+                result = Trakt['scrobble'].stop(
+                    show=show,
+                    episode=episode,
+                    progress=percent)
+            else:
+                    logger.debug("scrobble() Bad scrobble status")
+        return result
 
-	def scrobbleEpisode(self, show, episode, percent, status):
-		result = None
+    def scrobbleMovie(self, movie, percent, status):
+        result = None
 
-		with Trakt.configuration.auth(self.__username, self.__token):
-			if status == 'start':
-				with Trakt.configuration.http(retry=True):
-					result =Trakt['scrobble'].start(
-						show=show,
-						episode=episode,
-						progress=percent)
-			elif status == 'pause':
-				with Trakt.configuration.http(retry=True):
-					result = Trakt['scrobble'].pause(
-						show=show,
-						episode=episode,
-						progress=percent)
-			elif status == 'stop':
-				#don't retry on stop, this will cause multiple scrobbles
-				result = Trakt['scrobble'].stop(
-					show=show,
-					episode=episode,
-					progress=percent)
-			else:
-					logger.debug("scrobble() Bad scrobble status")
-		return result
+        with Trakt.configuration.auth(self.__username, self.__token):
+            if status == 'start':
+                with Trakt.configuration.http(retry=True):
+                    result = Trakt['scrobble'].start(
+                        movie=movie,
+                        progress=percent)
+            elif status == 'pause':
+                with Trakt.configuration.http(retry=True):
+                    result = Trakt['scrobble'].pause(
+                        movie=movie,
+                        progress=percent)
+            elif status == 'stop':
+                #don't retry on stop, this will cause multiple scrobbles
+                result = Trakt['scrobble'].stop(
+                    movie=movie,
+                    progress=percent)
+            else:
+                logger.debug("scrobble() Bad scrobble status")
+        return result
 
+    def getShowsCollected(self, shows):
+        with Trakt.configuration.auth(self.__username, self.__token):
+            with Trakt.configuration.http(retry=True, timeout=90):
+                Trakt['sync/collection'].shows(shows, exceptions=True)
+        return shows
 
-	def scrobbleMovie(self, movie, percent, status):
-		result = None
+    def getMoviesCollected(self, movies):
+        with Trakt.configuration.auth(self.__username, self.__token):
+            with Trakt.configuration.http(retry=True, timeout=90):
+                Trakt['sync/collection'].movies(movies, exceptions=True)
+        return movies
 
-		with Trakt.configuration.auth(self.__username, self.__token):
-			if status == 'start':
-				with Trakt.configuration.http(retry=True):
-					result = Trakt['scrobble'].start(
-						movie=movie,
-						progress=percent)
-			elif status == 'pause':
-				with Trakt.configuration.http(retry=True):
-					result = Trakt['scrobble'].pause(
-						movie=movie,
-						progress=percent)
-			elif status == 'stop':
-				#don't retry on stop, this will cause multiple scrobbles
-				result = Trakt['scrobble'].stop(
-					movie=movie,
-					progress=percent)
-			else:
-				logger.debug("scrobble() Bad scrobble status")
-		return result
+    def getShowsWatched(self, shows):
+        with Trakt.configuration.auth(self.__username, self.__token):
+            with Trakt.configuration.http(retry=True, timeout=90):
+                Trakt['sync/watched'].shows(shows, exceptions=True)
+        return shows
 
-	def getShowsCollected(self, shows):
-		with Trakt.configuration.auth(self.__username, self.__token):
-			with Trakt.configuration.http(retry=True, timeout=90):
-				Trakt['sync/collection'].shows(shows, exceptions=True)
-		return shows
+    def getMoviesWatched(self, movies):
+        with Trakt.configuration.auth(self.__username, self.__token):
+            with Trakt.configuration.http(retry=True, timeout=90):
+                Trakt['sync/watched'].movies(movies, exceptions=True)
+        return movies
 
-	def getMoviesCollected(self, movies):
-		with Trakt.configuration.auth(self.__username, self.__token):
-			with Trakt.configuration.http(retry=True, timeout=90):
-				Trakt['sync/collection'].movies(movies, exceptions=True)
-		return movies
+    def addToCollection(self, mediaObject):
+        with Trakt.configuration.auth(self.__username, self.__token):
+            with Trakt.configuration.http(retry=True):
+                result = Trakt['sync/collection'].add(mediaObject)
+        return result
 
-	def getShowsWatched(self, shows):
-		with Trakt.configuration.auth(self.__username, self.__token):
-			with Trakt.configuration.http(retry=True, timeout=90):
-				Trakt['sync/watched'].shows(shows, exceptions=True)
-		return shows
+    def removeFromCollection(self, mediaObject):
+        with Trakt.configuration.auth(self.__username, self.__token):
+            with Trakt.configuration.http(retry=True):
+                result = Trakt['sync/collection'].remove(mediaObject)
+        return result
 
-	def getMoviesWatched(self, movies):
-		with Trakt.configuration.auth(self.__username, self.__token):
-			with Trakt.configuration.http(retry=True, timeout=90):
-				Trakt['sync/watched'].movies(movies, exceptions=True)
-		return movies
+    def addToHistory(self, mediaObject):
+        with Trakt.configuration.auth(self.__username, self.__token):
+            #don't try this call it may cause multiple watches
+            result = Trakt['sync/history'].add(mediaObject)
+        return result
 
-	def addToCollection(self, mediaObject):
-		with Trakt.configuration.auth(self.__username, self.__token):
-			with Trakt.configuration.http(retry=True):
-				result = Trakt['sync/collection'].add(mediaObject)
-		return result
+    def getShowRatingForUser(self, showId, idType='tvdb'):
+        ratings = {}
+        with Trakt.configuration.auth(self.__username, self.__token):
+            with Trakt.configuration.http(retry=True):
+                Trakt['sync/ratings'].shows(ratings)
+        return findShowMatchInList(showId, ratings, idType)
 
-	def removeFromCollection(self, mediaObject):
-		with Trakt.configuration.auth(self.__username, self.__token):
-			with Trakt.configuration.http(retry=True):
-				result = Trakt['sync/collection'].remove(mediaObject)
-		return result
+    def getSeasonRatingForUser(self, showId, season, idType='tvdb'):
+        ratings = {}
+        with Trakt.configuration.auth(self.__username, self.__token):
+            with Trakt.configuration.http(retry=True):
+                Trakt['sync/ratings'].seasons(ratings)
+        return findSeasonMatchInList(showId, season, ratings, idType)
 
-	def addToHistory(self, mediaObject):
-		with Trakt.configuration.auth(self.__username, self.__token):
-			#don't try this call it may cause multiple watches
-			result = Trakt['sync/history'].add(mediaObject)
-		return result
+    def getEpisodeRatingForUser(self, showId, season, episode, idType='tvdb'):
+        ratings = {}
+        with Trakt.configuration.auth(self.__username, self.__token):
+            with Trakt.configuration.http(retry=True):
+                Trakt['sync/ratings'].episodes(ratings)
+        return findEpisodeMatchInList(showId, season, episode, ratings, idType)
 
-	def getShowRatingForUser(self, showId, idType='tvdb'):
-		ratings = {}
-		with Trakt.configuration.auth(self.__username, self.__token):
-			with Trakt.configuration.http(retry=True):
-				Trakt['sync/ratings'].shows(ratings)
-		return findShowMatchInList(showId, ratings, idType)
+    def getMovieRatingForUser(self, movieId, idType='imdb'):
+        ratings = {}
+        with Trakt.configuration.auth(self.__username, self.__token):
+            with Trakt.configuration.http(retry=True):
+                Trakt['sync/ratings'].movies(ratings)
+        return findMovieMatchInList(movieId, ratings, idType)
 
-	def getSeasonRatingForUser(self, showId, season, idType='tvdb'):
-		ratings = {}
-		with Trakt.configuration.auth(self.__username, self.__token):
-			with Trakt.configuration.http(retry=True):
-				Trakt['sync/ratings'].seasons(ratings)
-		return findSeasonMatchInList(showId, season, ratings, idType)
+    # Send a rating to Trakt as mediaObject so we can add the rating
+    def addRating(self, mediaObject):
+        with Trakt.configuration.auth(self.__username, self.__token):
+            with Trakt.configuration.http(retry=True):
+                result = Trakt['sync/ratings'].add(mediaObject)
+        return result
 
-	def getEpisodeRatingForUser(self, showId, season, episode, idType='tvdb'):
-		ratings = {}
-		with Trakt.configuration.auth(self.__username, self.__token):
-			with Trakt.configuration.http(retry=True):
-				Trakt['sync/ratings'].episodes(ratings)
-		return findEpisodeMatchInList(showId, season, episode, ratings, idType)
+    # Send a rating to Trakt as mediaObject so we can remove the rating
+    def removeRating(self, mediaObject):
+        with Trakt.configuration.auth(self.__username, self.__token):
+            with Trakt.configuration.http(retry=True):
+                result = Trakt['sync/ratings'].remove(mediaObject)
+        return result
 
-	def getMovieRatingForUser(self, movieId, idType='imdb'):
-		ratings = {}
-		with Trakt.configuration.auth(self.__username, self.__token):
-			with Trakt.configuration.http(retry=True):
-				Trakt['sync/ratings'].movies(ratings)
-		return findMovieMatchInList(movieId, ratings, idType)
+    def getMoviePlaybackProgress(self):
+        progressMovies = []
 
-	# Send a rating to Trakt as mediaObject so we can add the rating
-	def addRating(self, mediaObject):
-		with Trakt.configuration.auth(self.__username, self.__token):
-			with Trakt.configuration.http(retry=True):
-				result = Trakt['sync/ratings'].add(mediaObject)
-		return result
+        # Fetch playback
+        with Trakt.configuration.auth(self.__username, self.__token):
+            with Trakt.configuration.http(retry=True):
+                playback = Trakt['sync/playback'].movie(exceptions=True)
 
-	# Send a rating to Trakt as mediaObject so we can remove the rating
-	def removeRating(self, mediaObject):
-		with Trakt.configuration.auth(self.__username, self.__token):
-			with Trakt.configuration.http(retry=True):
-				result = Trakt['sync/ratings'].remove(mediaObject)
-		return result
+                for _, item in playback.items():
+                    if type(item) is Movie:
+                        progressMovies.append(item)
 
-	def getMoviePlaybackProgress(self):
-		progressMovies = []
+        return progressMovies
 
-		# Fetch playback
-		with Trakt.configuration.auth(self.__username, self.__token):
-			with Trakt.configuration.http(retry=True):
-				playback = Trakt['sync/playback'].movie(exceptions=True)
+    def getEpisodePlaybackProgress(self):
+        progressShows = []
 
-				for key, item in playback.items():
-					if type(item) is Movie:
-						progressMovies.append(item)
+        # Fetch playback
+        with Trakt.configuration.auth(self.__username, self.__token):
+            with Trakt.configuration.http(retry=True):
+                playback = Trakt['sync/playback'].shows(exceptions=True)
 
-		return progressMovies
+                for _, item in playback.items():
+                    if type(item) is Show:
+                        progressShows.append(item)
 
-	def getEpisodePlaybackProgress(self):
-		progressShows = []
+        return progressShows
 
-		# Fetch playback
-		with Trakt.configuration.auth(self.__username, self.__token):
-			with Trakt.configuration.http(retry=True):
-				playback = Trakt['sync/playback'].shows(exceptions=True)
+    def getMovieSummary(self, movieId):
+        with Trakt.configuration.http(retry=True):
+            return Trakt['movies'].get(movieId)
 
-				for key, item in playback.items():
-					if type(item) is Show:
-						progressShows.append(item)
+    def getShowSummary(self, showId):
+        with Trakt.configuration.http(retry=True):
+            return Trakt['shows'].get(showId)
 
-		return progressShows
-
-	def getMovieSummary(self, movieId):
-		with Trakt.configuration.http(retry=True):
-			return Trakt['movies'].get(movieId)
-
-	def getShowSummary(self, showId):
-		with Trakt.configuration.http(retry=True):
-			return Trakt['shows'].get(showId)
-
-	def getEpisodeSummary(self, showId, season, episode):
-		with Trakt.configuration.http(retry=True):
-			return Trakt['shows'].episode(showId, season, episode)
+    def getEpisodeSummary(self, showId, season, episode):
+        with Trakt.configuration.http(retry=True):
+            return Trakt['shows'].episode(showId, season, episode)

--- a/utilities.py
+++ b/utilities.py
@@ -13,10 +13,10 @@ from datetime import datetime
 from dateutil.tz import tzutc, tzlocal
 
 
-if sys.version_info >=  (2, 7):
-	import json as json
+if sys.version_info >= (2, 7):
+    import json as json
 else:
-	import simplejson as json
+    import simplejson as json
 
 # read settings
 __addon__ = xbmcaddon.Addon('script.trakt')
@@ -26,424 +26,424 @@ time.strptime("1970-01-01 12:00:00", "%Y-%m-%d %H:%M:%S")
 
 logger = logging.getLogger(__name__)
 
-REGEX_EXPRESSIONS = [ '[Ss]([0-9]+)[][._-]*[Ee]([0-9]+)([^\\\\/]*)$',
-					  '[\._ \-]([0-9]+)x([0-9]+)([^\\/]*)',                     # foo.1x09
-					  '[\._ \-]([0-9]+)([0-9][0-9])([\._ \-][^\\/]*)',          # foo.109
-					  '([0-9]+)([0-9][0-9])([\._ \-][^\\/]*)',
-					  '[\\\\/\\._ -]([0-9]+)([0-9][0-9])[^\\/]*',
-					  'Season ([0-9]+) - Episode ([0-9]+)[^\\/]*',              # Season 01 - Episode 02
-					  'Season ([0-9]+) Episode ([0-9]+)[^\\/]*',                # Season 01 Episode 02
-					  '[\\\\/\\._ -][0]*([0-9]+)x[0]*([0-9]+)[^\\/]*',
-					  '[[Ss]([0-9]+)\]_\[[Ee]([0-9]+)([^\\/]*)',                #foo_[s01]_[e01]
-					  '[\._ \-][Ss]([0-9]+)[\.\-]?[Ee]([0-9]+)([^\\/]*)',       #foo, s01e01, foo.s01.e01, foo.s01-e01
-					  's([0-9]+)ep([0-9]+)[^\\/]*',                             #foo - s01ep03, foo - s1ep03
-					  '[Ss]([0-9]+)[][ ._-]*[Ee]([0-9]+)([^\\\\/]*)$',
-					  '[\\\\/\\._ \\[\\(-]([0-9]+)x([0-9]+)([^\\\\/]*)$'
-					 ]
+REGEX_EXPRESSIONS = ['[Ss]([0-9]+)[][._-]*[Ee]([0-9]+)([^\\\\/]*)$',
+                      '[\._ \-]([0-9]+)x([0-9]+)([^\\/]*)',  # foo.1x09
+                      '[\._ \-]([0-9]+)([0-9][0-9])([\._ \-][^\\/]*)',  # foo.109
+                      '([0-9]+)([0-9][0-9])([\._ \-][^\\/]*)',
+                      '[\\\\/\\._ -]([0-9]+)([0-9][0-9])[^\\/]*',
+                      'Season ([0-9]+) - Episode ([0-9]+)[^\\/]*',  # Season 01 - Episode 02
+                      'Season ([0-9]+) Episode ([0-9]+)[^\\/]*',  # Season 01 Episode 02
+                      '[\\\\/\\._ -][0]*([0-9]+)x[0]*([0-9]+)[^\\/]*',
+                      '[[Ss]([0-9]+)\]_\[[Ee]([0-9]+)([^\\/]*)',  # foo_[s01]_[e01]
+                      '[\._ \-][Ss]([0-9]+)[\.\-]?[Ee]([0-9]+)([^\\/]*)',  # foo, s01e01, foo.s01.e01, foo.s01-e01
+                      's([0-9]+)ep([0-9]+)[^\\/]*',  # foo - s01ep03, foo - s1ep03
+                      '[Ss]([0-9]+)[][ ._-]*[Ee]([0-9]+)([^\\\\/]*)$',
+                      '[\\\\/\\._ \\[\\(-]([0-9]+)x([0-9]+)([^\\\\/]*)$'
+                     ]
 
 REGEX_YEAR = '^(.+) \((\d{4})\)$'
 
 def notification(header, message, time=5000, icon=__addon__.getAddonInfo('icon')):
-	xbmc.executebuiltin("XBMC.Notification(%s,%s,%i,%s)" % (header, message, time, icon))
+    xbmc.executebuiltin("XBMC.Notification(%s,%s,%i,%s)" % (header, message, time, icon))
 
 def showSettings():
-	__addon__.openSettings()
+    __addon__.openSettings()
 
 def getSetting(setting):
-	return __addon__.getSetting(setting).strip()
+    return __addon__.getSetting(setting).strip()
 
 def getSettingAsBool(setting):
-	return getSetting(setting).lower() == "true"
+    return getSetting(setting).lower() == "true"
 
 def getSettingAsFloat(setting):
-	try:
-		return float(getSetting(setting))
-	except ValueError:
-		return 0
+    try:
+        return float(getSetting(setting))
+    except ValueError:
+        return 0
 
 def getSettingAsInt(setting):
-	try:
-		return int(getSettingAsFloat(setting))
-	except ValueError:
-		return 0
+    try:
+        return int(getSettingAsFloat(setting))
+    except ValueError:
+        return 0
 
 def getString(string_id):
-	return __addon__.getLocalizedString(string_id).encode('utf-8', 'ignore')
+    return __addon__.getLocalizedString(string_id).encode('utf-8', 'ignore')
 
 def isMovie(type):
-	return type == 'movie'
+    return type == 'movie'
 
 def isEpisode(type):
-	return type == 'episode'
+    return type == 'episode'
 
 def isShow(type):
-	return type == 'show'
+    return type == 'show'
 
 def isSeason(type):
-	return type == 'season'
+    return type == 'season'
 
 def isValidMediaType(type):
-	return type in ['movie', 'show', 'season', 'episode']
+    return type in ['movie', 'show', 'season', 'episode']
 
 def kodiJsonRequest(params):
-	data = json.dumps(params)
-	request = xbmc.executeJSONRPC(data)
+    data = json.dumps(params)
+    request = xbmc.executeJSONRPC(data)
 
-	try:
-		response = json.loads(request)
-	except UnicodeDecodeError:
-		response = json.loads(request.decode('utf-8', 'ignore'))
+    try:
+        response = json.loads(request)
+    except UnicodeDecodeError:
+        response = json.loads(request.decode('utf-8', 'ignore'))
 
-	try:
-		if 'result' in response:
-			return response['result']
-		return None
-	except KeyError:
-		logger.warn("[%s] %s" % (params['method'], response['error']['message']))
-		return None
+    try:
+        if 'result' in response:
+            return response['result']
+        return None
+    except KeyError:
+        logger.warn("[%s] %s" % (params['method'], response['error']['message']))
+        return None
 
 def chunks(l, n):
-	return [l[i:i+n] for i in range(0, len(l), n)]
+    return [l[i:i + n] for i in range(0, len(l), n)]
 
 # check exclusion settings for filename passed as argument
 def checkExclusion(fullpath):
 
-	if not fullpath:
-		return True
+    if not fullpath:
+        return True
 
-	if (fullpath.find("pvr://") > -1) and getSettingAsBool('ExcludeLiveTV'):
-		logger.debug("checkExclusion(): Video is playing via Live TV, which is currently set as excluded location.")
-		return True
+    if (fullpath.find("pvr://") > -1) and getSettingAsBool('ExcludeLiveTV'):
+        logger.debug("checkExclusion(): Video is playing via Live TV, which is currently set as excluded location.")
+        return True
 
-	if (fullpath.find("http://") > -1) and getSettingAsBool('ExcludeHTTP'):
-		logger.debug("checkExclusion(): Video is playing via HTTP source, which is currently set as excluded location.")
-		return True
+    if (fullpath.find("http://") > -1) and getSettingAsBool('ExcludeHTTP'):
+        logger.debug("checkExclusion(): Video is playing via HTTP source, which is currently set as excluded location.")
+        return True
 
-	ExcludePath = getSetting('ExcludePath')
-	if ExcludePath != "" and getSettingAsBool('ExcludePathOption'):
-		if fullpath.find(ExcludePath) > -1:
-			logger.debug("checkExclusion(): Video is from location, which is currently set as excluded path 1.")
-			return True
+    ExcludePath = getSetting('ExcludePath')
+    if ExcludePath != "" and getSettingAsBool('ExcludePathOption'):
+        if fullpath.find(ExcludePath) > -1:
+            logger.debug("checkExclusion(): Video is from location, which is currently set as excluded path 1.")
+            return True
 
-	ExcludePath2 = getSetting('ExcludePath2')
-	if ExcludePath2 != "" and getSettingAsBool('ExcludePathOption2'):
-		if fullpath.find(ExcludePath2) > -1:
-			logger.debug("checkExclusion(): Video is from location, which is currently set as excluded path 2.")
-			return True
+    ExcludePath2 = getSetting('ExcludePath2')
+    if ExcludePath2 != "" and getSettingAsBool('ExcludePathOption2'):
+        if fullpath.find(ExcludePath2) > -1:
+            logger.debug("checkExclusion(): Video is from location, which is currently set as excluded path 2.")
+            return True
 
-	ExcludePath3 = getSetting('ExcludePath3')
-	if ExcludePath3 != "" and getSettingAsBool('ExcludePathOption3'):
-		if fullpath.find(ExcludePath3) > -1:
-			logger.debug("checkExclusion(): Video is from location, which is currently set as excluded path 3.")
-			return True
+    ExcludePath3 = getSetting('ExcludePath3')
+    if ExcludePath3 != "" and getSettingAsBool('ExcludePathOption3'):
+        if fullpath.find(ExcludePath3) > -1:
+            logger.debug("checkExclusion(): Video is from location, which is currently set as excluded path 3.")
+            return True
 
-	return False
+    return False
 
 def getFormattedItemName(type, info):
-	s = None
-	if isShow(type):
-		s = info['title']
-	elif isEpisode(type):
-			s = "S%02dE%02d - %s" % (info['season'], info['number'], info['title'])
-	elif isSeason(type):
-		if info['season'] > 0:
-			s = "%s - Season %d" % (info['title'], info['season'])
-		else:
-			s = "%s - Specials" % info['title']
-	elif isMovie(type):
-		s = "%s (%s)" % (info['title'], info['year'])
-	return s.encode('utf-8', 'ignore')
+    s = None
+    if isShow(type):
+        s = info['title']
+    elif isEpisode(type):
+            s = "S%02dE%02d - %s" % (info['season'], info['number'], info['title'])
+    elif isSeason(type):
+        if info['season'] > 0:
+            s = "%s - Season %d" % (info['title'], info['season'])
+        else:
+            s = "%s - Specials" % info['title']
+    elif isMovie(type):
+        s = "%s (%s)" % (info['title'], info['year'])
+    return s.encode('utf-8', 'ignore')
 
 def getShowDetailsFromKodi(showID, fields):
-	result = kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetTVShowDetails', 'params':{'tvshowid': showID, 'properties': fields}, 'id': 1})
-	logger.debug("getShowDetailsFromKodi(): %s" % str(result))
+    result = kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetTVShowDetails', 'params': {'tvshowid': showID, 'properties': fields}, 'id': 1})
+    logger.debug("getShowDetailsFromKodi(): %s" % str(result))
 
-	if not result:
-		logger.debug("getShowDetailsFromKodi(): Result from Kodi was empty.")
-		return None
+    if not result:
+        logger.debug("getShowDetailsFromKodi(): Result from Kodi was empty.")
+        return None
 
-	try:
-		return result['tvshowdetails']
-	except KeyError:
-		logger.debug("getShowDetailsFromKodi(): KeyError: result['tvshowdetails']")
-		return None
+    try:
+        return result['tvshowdetails']
+    except KeyError:
+        logger.debug("getShowDetailsFromKodi(): KeyError: result['tvshowdetails']")
+        return None
 
 # get a single episode from kodi given the id
 def getEpisodeDetailsFromKodi(libraryId, fields):
-	result = kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetEpisodeDetails', 'params':{'episodeid': libraryId, 'properties': fields}, 'id': 1})
-	logger.debug("getEpisodeDetailsFromKodi(): %s" % str(result))
+    result = kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetEpisodeDetails', 'params': {'episodeid': libraryId, 'properties': fields}, 'id': 1})
+    logger.debug("getEpisodeDetailsFromKodi(): %s" % str(result))
 
-	if not result:
-		logger.debug("getEpisodeDetailsFromKodi(): Result from Kodi was empty.")
-		return None
+    if not result:
+        logger.debug("getEpisodeDetailsFromKodi(): Result from Kodi was empty.")
+        return None
 
-	show_data = getShowDetailsFromKodi(result['episodedetails']['tvshowid'], ['year', 'imdbnumber'])
+    show_data = getShowDetailsFromKodi(result['episodedetails']['tvshowid'], ['year', 'imdbnumber'])
 
-	if not show_data:
-		logger.debug("getEpisodeDetailsFromKodi(): Result from getShowDetailsFromKodi() was empty.")
-		return None
+    if not show_data:
+        logger.debug("getEpisodeDetailsFromKodi(): Result from getShowDetailsFromKodi() was empty.")
+        return None
 
-	result['episodedetails']['imdbnumber'] = show_data['imdbnumber']
-	result['episodedetails']['year'] = show_data['year']
+    result['episodedetails']['imdbnumber'] = show_data['imdbnumber']
+    result['episodedetails']['year'] = show_data['year']
 
-	try:
-		return result['episodedetails']
-	except KeyError:
-		logger.debug("getEpisodeDetailsFromKodi(): KeyError: result['episodedetails']")
-		return None
+    try:
+        return result['episodedetails']
+    except KeyError:
+        logger.debug("getEpisodeDetailsFromKodi(): KeyError: result['episodedetails']")
+        return None
 
 # get a single movie from kodi given the id
 def getMovieDetailsFromKodi(libraryId, fields):
-	result = kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetMovieDetails', 'params':{'movieid': libraryId, 'properties': fields}, 'id': 1})
-	logger.debug("getMovieDetailsFromKodi(): %s" % str(result))
+    result = kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetMovieDetails', 'params': {'movieid': libraryId, 'properties': fields}, 'id': 1})
+    logger.debug("getMovieDetailsFromKodi(): %s" % str(result))
 
-	if not result:
-		logger.debug("getMovieDetailsFromKodi(): Result from Kodi was empty.")
-		return None
+    if not result:
+        logger.debug("getMovieDetailsFromKodi(): Result from Kodi was empty.")
+        return None
 
-	try:
-		return result['moviedetails']
-	except KeyError:
-		logger.debug("getMovieDetailsFromKodi(): KeyError: result['moviedetails']")
-		return None
+    try:
+        return result['moviedetails']
+    except KeyError:
+        logger.debug("getMovieDetailsFromKodi(): KeyError: result['moviedetails']")
+        return None
 
 def __findInList(list, case_sensitive=True, **kwargs):
-	for item in list:
-		i = 0
-		for key in kwargs:
-			# becuause we can need to find at the root level and inside ids this is is required
-			if key in item:
-				key_val = item[key]
-			else:
-				if 'ids' in item and key in item['ids']:
-					key_val = item['ids'][key]
-				else:
-					continue
-			if not case_sensitive and isinstance(key_val, basestring):
-				if key_val.lower() == kwargs[key].lower():
-					i = i + 1
-			else:
-				# forcing the compare to be done at the string level
-				if unicode(key_val) == unicode(kwargs[key]):
-					i = i + 1
-		if i == len(kwargs):
-			return item
-	return None
+    for item in list:
+        i = 0
+        for key in kwargs:
+            # becuause we can need to find at the root level and inside ids this is is required
+            if key in item:
+                key_val = item[key]
+            else:
+                if 'ids' in item and key in item['ids']:
+                    key_val = item['ids'][key]
+                else:
+                    continue
+            if not case_sensitive and isinstance(key_val, basestring):
+                if key_val.lower() == kwargs[key].lower():
+                    i = i + 1
+            else:
+                # forcing the compare to be done at the string level
+                if unicode(key_val) == unicode(kwargs[key]):
+                    i = i + 1
+        if i == len(kwargs):
+            return item
+    return None
 
 def findMediaObject(mediaObjectToMatch, listToSearch):
-	result = None
-	if result is None and 'ids' in mediaObjectToMatch and 'imdb' in mediaObjectToMatch['ids'] and unicode(mediaObjectToMatch['ids']['imdb']).startswith("tt"):
-		result = __findInList(listToSearch, imdb=mediaObjectToMatch['ids']['imdb'])
-	# we don't want to give up if we don't find a match based on the first field so we use if instead of elif
-	if result is None and 'ids' in mediaObjectToMatch and 'tmdb' in mediaObjectToMatch['ids'] and mediaObjectToMatch['ids']['tmdb'].isdigit():
-		result = __findInList(listToSearch, tmdb=mediaObjectToMatch['ids']['tmdb'])
-	if result is None and 'ids' in mediaObjectToMatch and 'tvdb' in mediaObjectToMatch['ids'] and mediaObjectToMatch['ids']['tvdb'].isdigit():
-		result = __findInList(listToSearch, tvdb=mediaObjectToMatch['ids']['tvdb'])
-	# match by title and year it will result in movies with the same title and year to mismatch - but what should we do instead?
-	if result is None and 'title' in mediaObjectToMatch and 'year' in mediaObjectToMatch:
-		result = __findInList(listToSearch, title=mediaObjectToMatch['title'], year=mediaObjectToMatch['year'])
-	return result
+    result = None
+    if result is None and 'ids' in mediaObjectToMatch and 'imdb' in mediaObjectToMatch['ids'] and unicode(mediaObjectToMatch['ids']['imdb']).startswith("tt"):
+        result = __findInList(listToSearch, imdb=mediaObjectToMatch['ids']['imdb'])
+    # we don't want to give up if we don't find a match based on the first field so we use if instead of elif
+    if result is None and 'ids' in mediaObjectToMatch and 'tmdb' in mediaObjectToMatch['ids'] and mediaObjectToMatch['ids']['tmdb'].isdigit():
+        result = __findInList(listToSearch, tmdb=mediaObjectToMatch['ids']['tmdb'])
+    if result is None and 'ids' in mediaObjectToMatch and 'tvdb' in mediaObjectToMatch['ids'] and mediaObjectToMatch['ids']['tvdb'].isdigit():
+        result = __findInList(listToSearch, tvdb=mediaObjectToMatch['ids']['tvdb'])
+    # match by title and year it will result in movies with the same title and year to mismatch - but what should we do instead?
+    if result is None and 'title' in mediaObjectToMatch and 'year' in mediaObjectToMatch:
+        result = __findInList(listToSearch, title=mediaObjectToMatch['title'], year=mediaObjectToMatch['year'])
+    return result
 
-def regex_tvshow(compare, file, sub = ""):
-	tvshow = 0
+def regex_tvshow(compare, file, sub=""):
+    tvshow = 0
 
-	for regex in REGEX_EXPRESSIONS:
-		response_file = re.findall(regex, file)
-		if len(response_file) > 0 :
-			logger.debug("regex_tvshow(): Regex File Se: %s, Ep: %s," % (str(response_file[0][0]),str(response_file[0][1]),) )
-			tvshow = 1
-			if not compare :
-				title = re.split(regex, file)[0]
-				for char in ['[', ']', '_', '(', ')','.','-']:
-					title = title.replace(char, ' ')
-				if title.endswith(" "): title = title[:-1]
-				return title,response_file[0][0], response_file[0][1]
-			else:
-				break
+    for regex in REGEX_EXPRESSIONS:
+        response_file = re.findall(regex, file)
+        if len(response_file) > 0:
+            logger.debug("regex_tvshow(): Regex File Se: %s, Ep: %s," % (str(response_file[0][0]), str(response_file[0][1]),))
+            tvshow = 1
+            if not compare:
+                title = re.split(regex, file)[0]
+                for char in ['[', ']', '_', '(', ')', '.', '-']:
+                    title = title.replace(char, ' ')
+                if title.endswith(" "): title = title[:-1]
+                return title, response_file[0][0], response_file[0][1]
+            else:
+                break
 
-	if tvshow == 1:
-		for regex in REGEX_EXPRESSIONS:
-			response_sub = re.findall(regex, sub)
-			if len(response_sub) > 0 :
-				try :
-					if int(response_sub[0][1]) == int(response_file[0][1]):
-						return True
-				except: pass
-		return False
-	if compare :
-		return True
-	else:
-		return "","",""
+    if tvshow == 1:
+        for regex in REGEX_EXPRESSIONS:
+            response_sub = re.findall(regex, sub)
+            if len(response_sub) > 0:
+                try:
+                    if int(response_sub[0][1]) == int(response_file[0][1]):
+                        return True
+                except: pass
+        return False
+    if compare:
+        return True
+    else:
+        return "", "", ""
 
 def regex_year(title):
-	prog = re.compile(REGEX_YEAR)
-	result = prog.match(title)
+    prog = re.compile(REGEX_YEAR)
+    result = prog.match(title)
 
-	if result:
-		return result.group(1), result.group(2)
-	else:
-		return "", ""
+    if result:
+        return result.group(1), result.group(2)
+    else:
+        return "", ""
 
 def findMovieMatchInList(id, list, idType):
-	return next((item.to_dict() for key, item in list.items() if any(idType in key for key, value in item.keys if str(value) == str(id))), {})
+    return next((item.to_dict() for key, item in list.items() if any(idType in key for key, value in item.keys if str(value) == str(id))), {})
 
 def findShowMatchInList(id, list, idType):
-	return next((item.to_dict() for key, item in list.items() if  any(idType in key for key, value in item.keys if str(value) == str(id))), {})
+    return next((item.to_dict() for key, item in list.items() if  any(idType in key for key, value in item.keys if str(value) == str(id))), {})
 
 def findSeasonMatchInList(id, seasonNumber, list, idType):
-	show = findShowMatchInList(id, list, idType)
-	logger.debug("findSeasonMatchInList %s" % show)
-	if 'seasons' in show:
-		for season in show['seasons']:
-			if season['number'] == seasonNumber:
-				return season
+    show = findShowMatchInList(id, list, idType)
+    logger.debug("findSeasonMatchInList %s" % show)
+    if 'seasons' in show:
+        for season in show['seasons']:
+            if season['number'] == seasonNumber:
+                return season
 
-	return {}
+    return {}
 
 def findEpisodeMatchInList(id, seasonNumber, episodeNumber, list, idType):
-	season = findSeasonMatchInList(id, seasonNumber, list, idType)
-	if season:
-		for episode in season['episodes']:
-			if episode['number'] == episodeNumber:
-				return episode
+    season = findSeasonMatchInList(id, seasonNumber, list, idType)
+    if season:
+        for episode in season['episodes']:
+            if episode['number'] == episodeNumber:
+                return episode
 
-	return {}
+    return {}
 
 def kodiRpcToTraktMediaObject(type, data, mode='collected'):
-	if type == 'tvshow':
-		data['ids'] = {}
-		id = data.pop('imdbnumber')
-		if id.startswith("tt"):
-			data['ids']['imdb'] = id
-		elif id.isdigit():
-			data['ids']['tvdb'] = id
-		del(data['label'])
-		return data
-	elif type == 'episode':
-		if checkExclusion(data['file']):
-			return
+    if type == 'tvshow':
+        data['ids'] = {}
+        id = data.pop('imdbnumber')
+        if id.startswith("tt"):
+            data['ids']['imdb'] = id
+        elif id.isdigit():
+            data['ids']['tvdb'] = id
+        del(data['label'])
+        return data
+    elif type == 'episode':
+        if checkExclusion(data['file']):
+            return
 
-		if data['playcount'] is None:
-			plays = 0
-		else:
-			plays = data.pop('playcount')
+        if data['playcount'] is None:
+            plays = 0
+        else:
+            plays = data.pop('playcount')
 
-		if plays > 0:
-			watched = 1
-		else:
-			watched = 0
+        if plays > 0:
+            watched = 1
+        else:
+            watched = 0
 
-		episode = { 'season': data['season'], 'number': data['episode'], 'title': data['label'],
-		            'ids': { 'tvdb': data['uniqueid']['unknown'], 'episodeid' : data['episodeid']}, 'watched': watched, 'plays': plays }
-		episode['collected'] = 1 #this is in our kodi so it should be collected
-		if 'lastplayed' in data:
-			episode['watched_at'] = convertDateTimeToUTC(data['lastplayed'])
-		if 'dateadded' in data:
-			episode['collected_at'] = convertDateTimeToUTC(data['dateadded'])
-		if 'runtime' in data:
-			episode['runtime'] = data['runtime']
-		if mode == 'watched' and episode['watched']:
-			return episode
-		elif mode == 'collected' and episode['collected']:
-			return episode
-		else:
-			return
+        episode = {'season': data['season'], 'number': data['episode'], 'title': data['label'],
+                    'ids': {'tvdb': data['uniqueid']['unknown'], 'episodeid': data['episodeid']}, 'watched': watched, 'plays': plays}
+        episode['collected'] = 1  # this is in our kodi so it should be collected
+        if 'lastplayed' in data:
+            episode['watched_at'] = convertDateTimeToUTC(data['lastplayed'])
+        if 'dateadded' in data:
+            episode['collected_at'] = convertDateTimeToUTC(data['dateadded'])
+        if 'runtime' in data:
+            episode['runtime'] = data['runtime']
+        if mode == 'watched' and episode['watched']:
+            return episode
+        elif mode == 'collected' and episode['collected']:
+            return episode
+        else:
+            return
 
-	elif type == 'movie':
-		if checkExclusion(data.pop('file')):
-			return
-		if 'lastplayed' in data:
-			data['watched_at'] = convertDateTimeToUTC(data.pop('lastplayed'))
-		if 'dateadded' in data:
-			data['collected_at'] = convertDateTimeToUTC(data.pop('dateadded'))
-		if data['playcount'] is None:
-			data['plays'] = 0
-		else:
-			data['plays'] = data.pop('playcount')
-		data['collected'] = 1 #this is in our kodi so it should be collected
-		data['watched'] = 1 if data['plays'] > 0 else 0
-		data['ids'] = {}
-		id = data.pop('imdbnumber')
-		if id.startswith("tt"):
-			data['ids']['imdb'] = id
-		elif id.isdigit():
-			data['ids']['tmdb'] = id
-		del(data['label'])
-		return data
-	else:
-		logger.debug('kodiRpcToTraktMediaObject() No valid type')
-		return
+    elif type == 'movie':
+        if checkExclusion(data.pop('file')):
+            return
+        if 'lastplayed' in data:
+            data['watched_at'] = convertDateTimeToUTC(data.pop('lastplayed'))
+        if 'dateadded' in data:
+            data['collected_at'] = convertDateTimeToUTC(data.pop('dateadded'))
+        if data['playcount'] is None:
+            data['plays'] = 0
+        else:
+            data['plays'] = data.pop('playcount')
+        data['collected'] = 1  # this is in our kodi so it should be collected
+        data['watched'] = 1 if data['plays'] > 0 else 0
+        data['ids'] = {}
+        id = data.pop('imdbnumber')
+        if id.startswith("tt"):
+            data['ids']['imdb'] = id
+        elif id.isdigit():
+            data['ids']['tmdb'] = id
+        del(data['label'])
+        return data
+    else:
+        logger.debug('kodiRpcToTraktMediaObject() No valid type')
+        return
 
 def kodiRpcToTraktMediaObjects(data, mode='collected'):
-	if 'tvshows' in data:
-		shows = data['tvshows']
+    if 'tvshows' in data:
+        shows = data['tvshows']
 
-		# reformat show array
-		for show in shows:
-			kodiRpcToTraktMediaObject('tvshow', show, mode)
-		return shows
+        # reformat show array
+        for show in shows:
+            kodiRpcToTraktMediaObject('tvshow', show, mode)
+        return shows
 
-	elif 'episodes' in data:
-		a_episodes = {}
-		seasons = []
-		for episode in data['episodes']:
-			while not episode['season'] in a_episodes :
-				s_no = episode['season']
-				a_episodes[s_no] = []
-			s_no = episode['season']
-			episodeObject = kodiRpcToTraktMediaObject('episode', episode, mode)
-			if episodeObject:
-				a_episodes[s_no].append(episodeObject)
+    elif 'episodes' in data:
+        a_episodes = {}
+        seasons = []
+        for episode in data['episodes']:
+            while not episode['season'] in a_episodes:
+                s_no = episode['season']
+                a_episodes[s_no] = []
+            s_no = episode['season']
+            episodeObject = kodiRpcToTraktMediaObject('episode', episode, mode)
+            if episodeObject:
+                a_episodes[s_no].append(episodeObject)
 
-		for episode in a_episodes:
-			seasons.append({'number': episode, 'episodes': a_episodes[episode]})
-		return seasons
+        for episode in a_episodes:
+            seasons.append({'number': episode, 'episodes': a_episodes[episode]})
+        return seasons
 
-	elif 'movies' in data:
-		movies = data['movies']
-		kodi_movies = []
+    elif 'movies' in data:
+        movies = data['movies']
+        kodi_movies = []
 
-		# reformat movie array
-		for movie in movies:
-			movieObject = kodiRpcToTraktMediaObject('movie', movie, mode)
-			if movieObject:
-				kodi_movies.append(movieObject)
-		return kodi_movies
-	else:
-		logger.debug('kodiRpcToTraktMediaObjects() No valid key found in rpc data')
-		return
+        # reformat movie array
+        for movie in movies:
+            movieObject = kodiRpcToTraktMediaObject('movie', movie, mode)
+            if movieObject:
+                kodi_movies.append(movieObject)
+        return kodi_movies
+    else:
+        logger.debug('kodiRpcToTraktMediaObjects() No valid key found in rpc data')
+        return
 
 def convertDateTimeToUTC(toConvert):
-	if toConvert:
-		dateFormat = "%Y-%m-%d %H:%M:%S"
-		try:
-			naive = datetime.strptime(toConvert, dateFormat)
-		except TypeError:
-			naive = datetime(*(time.strptime(toConvert, dateFormat)[0:6]))
-		local = naive.replace(tzinfo=tzlocal())
-		utc = local.astimezone(tzutc())
+    if toConvert:
+        dateFormat = "%Y-%m-%d %H:%M:%S"
+        try:
+            naive = datetime.strptime(toConvert, dateFormat)
+        except TypeError:
+            naive = datetime(*(time.strptime(toConvert, dateFormat)[0:6]))
+        local = naive.replace(tzinfo=tzlocal())
+        utc = local.astimezone(tzutc())
 
-		return unicode(utc)
-	else:
-		return toConvert
+        return unicode(utc)
+    else:
+        return toConvert
 
 def convertUtcToDateTime(toConvert):
-	if toConvert:
-		naive = dateutil.parser.parse(toConvert)
-		utc = naive.replace(tzinfo=tzutc())
-		local = utc.astimezone(tzlocal())
+    if toConvert:
+        naive = dateutil.parser.parse(toConvert)
+        utc = naive.replace(tzinfo=tzutc())
+        local = utc.astimezone(tzlocal())
 
-		return local.strftime("%Y-%m-%d %H:%M:%S")
-	else:
-		return toConvert
+        return local.strftime("%Y-%m-%d %H:%M:%S")
+    else:
+        return toConvert
 
 def createError(ex):
-	template = (
-			"EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--\n"
-			" - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!\n"
-			"Error Type: <type '{0}'>\n"
-			"Error Contents: {1!r}\n"
-			"{2}"
-			"-->End of Python script error report<--"
-			)
-	return template.format(type(ex).__name__, ex.args, traceback.format_exc())
+    template = (
+            "EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--\n"
+            " - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!\n"
+            "Error Type: <type '{0}'>\n"
+            "Error Contents: {1!r}\n"
+            "{2}"
+            "-->End of Python script error report<--"
+            )
+    return template.format(type(ex).__name__, ex.args, traceback.format_exc())

--- a/utilities.py
+++ b/utilities.py
@@ -256,7 +256,8 @@ def regex_tvshow(compare, file, sub=""):
                 title = re.split(regex, file)[0]
                 for char in ['[', ']', '_', '(', ')', '.', '-']:
                     title = title.replace(char, ' ')
-                if title.endswith(" "): title = title[:-1]
+                if title.endswith(" "):
+                    title = title[:-1]
                 return title, response_file[0][0], response_file[0][1]
             else:
                 break
@@ -268,7 +269,8 @@ def regex_tvshow(compare, file, sub=""):
                 try:
                     if int(response_sub[0][1]) == int(response_file[0][1]):
                         return True
-                except: pass
+                except:
+                    pass
         return False
     if compare:
         return True


### PR DESCRIPTION
Here's the pep8 cleanup. I made sure not to make any logic changes here to avoid hard to track down issues.

Note, I exclude a few pep8 recommendations when I run the pep8 checker that I think are a little over the top. The ones I exclude are: E501,E302,E701,W293. You can see what each check is here: http://pep8.readthedocs.org/en/latest/intro.html#example-usage-and-output

The one thing I didn't change was in sqlitequeue.py and utilities.py there are LOTS of assignment to reserved words like "file", "id", "list", etc. Let me know if you want me to clean those up as well. They are somewhat dangerous as they can cause hard to track down issues where the variable hides the keyword or vice versa.

Once you merge this, I'll pull it back down and push out a new beta.