### PR TITLE
Fix to show ratings

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.trakt" name="Trakt" version="3.0.1" provider-name="Trakt.tv">
+<addon id="script.trakt" name="Trakt" version="3.0.1~beta7" provider-name="Trakt.tv">
 	<requires>
 		<import addon="xbmc.python" version="2.1.0"/>
 		<import addon="script.module.simplejson" version="3.3.0"/>

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.trakt" name="Trakt" version="3.0.1~beta9" provider-name="Trakt.tv">
+<addon id="script.trakt" name="Trakt" version="3.0.1~beta10" provider-name="Trakt.tv">
 	<requires>
 		<import addon="xbmc.python" version="2.1.0"/>
 		<import addon="script.module.simplejson" version="3.3.0"/>

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.trakt" name="Trakt" version="3.0.1~beta10" provider-name="Trakt.tv">
+<addon id="script.trakt" name="Trakt" version="3.0.1" provider-name="Trakt.tv">
 	<requires>
 		<import addon="xbmc.python" version="2.20.0"/>
 		<import addon="script.module.simplejson" version="3.3.0"/>

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.trakt" name="Trakt" version="3.0.1~beta8" provider-name="Trakt.tv">
+<addon id="script.trakt" name="Trakt" version="3.0.1~beta9" provider-name="Trakt.tv">
 	<requires>
 		<import addon="xbmc.python" version="2.1.0"/>
 		<import addon="script.module.simplejson" version="3.3.0"/>

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.trakt" name="Trakt" version="3.0.1~beta7" provider-name="Trakt.tv">
+<addon id="script.trakt" name="Trakt" version="3.0.1~beta8" provider-name="Trakt.tv">
 	<requires>
 		<import addon="xbmc.python" version="2.1.0"/>
 		<import addon="script.module.simplejson" version="3.3.0"/>

--- a/script.py
+++ b/script.py
@@ -111,26 +111,36 @@ def Main():
                     if not result:
                         logger.debug("No data was returned from Kodi, aborting manual %s." % args['action'])
                         return
-                    data['imdbnumber'] = result['imdbnumber']
 
-                elif utils.isShow(media_type) or utils.isSeason(media_type):
-                    result = utils.getShowDetailsFromKodi(data['dbid'], ['imdbnumber', 'tag'])
+                elif utils.isShow(media_type):
+                    tvshow_id = data['dbid']
+
+                elif utils.isSeason(media_type):
+                    result = utils.getSeasonDetailsFromKodi(data['dbid'], ['tvshowid', 'season'])
                     if not result:
                         logger.debug("No data was returned from Kodi, aborting manual %s." % args['action'])
                         return
-                    data['imdbnumber'] = result['imdbnumber']
-                    data['tag'] = result['tag']
+                    tvshow_id = result['tvshowid']
+                    data['season'] = result['season']
 
                 elif utils.isEpisode(media_type):
-                    result = utils.getEpisodeDetailsFromKodi(data['dbid'], ['showtitle', 'season', 'episode', 'tvshowid', 'uniqueid', 'file', 'playcount'])
+                    result = utils.getEpisodeDetailsFromKodi(data['dbid'], ['season', 'episode', 'tvshowid'])
                     if not result:
                         logger.debug("No data was returned from Kodi, aborting manual %s." % args['action'])
                         return
-                    data['imdbnumber'] = result['episodeid']
+                    tvshow_id = result['tvshowid']
                     data['season'] = result['season']
                     data['episode'] = result['episode']
+
+                if utils.isShow(media_type) or utils.isSeason(media_type) or utils.isEpisode(media_type):
+                    result = utils.getShowDetailsFromKodi(tvshow_id, ['imdbnumber'])
+                    if not result:
+                        logger.debug("No data was returned from Kodi, aborting manual %s." % args['action'])
+                        return
+                    
+                data['video_id'] = result['imdbnumber']
             else:
-                data['imdbnumber'] = data['remoteid']
+                data['video_id'] = data['remoteid']
                 if 'season' in data and 'episode' in data:
                     logger.debug("Manual %s of non-library '%s' S%02dE%02d, with an ID of '%s'." % (args['action'], media_type, data['season'], data['episode'], data['remoteid']))
                 elif 'season' in data:

--- a/service.py
+++ b/service.py
@@ -137,7 +137,7 @@ class traktService:
 
         logger.debug("Getting data for manual %s of %s: imdb: |%s| dbid: |%s|" % (action, media_type, data.get('remoteid'), data.get('dbid')))
 
-        idDict, id_type = utilities.parseIdToTraktIds(str(data['imdbnumber']), media_type)
+        _, id_type = utilities.parseIdToTraktIds(str(data['imdbnumber']), media_type)
 
         if utilities.isEpisode(media_type):
             summaryInfo = globals.traktapi.getEpisodeSummary(data['imdbnumber'], data['season'], data['episode'])
@@ -147,7 +147,6 @@ class traktService:
             userInfo = globals.traktapi.getSeasonRatingForUser(data['imdbnumber'], data['season'], id_type)
         elif utilities.isShow(media_type):
             imdb = dict(globals.traktapi.getIdLookup(data['imdbnumber'], id_type)[0].keys)['imdb']
-
             summaryInfo = globals.traktapi.getShowSummary(imdb)
             userInfo = globals.traktapi.getShowRatingForUser(data['imdbnumber'], id_type)
         elif utilities.isMovie(media_type):

--- a/traktapi.py
+++ b/traktapi.py
@@ -279,4 +279,7 @@ class traktAPI(object):
 
     def getIdLookup(self, id, id_type):
         with Trakt.configuration.http(retry=True):
-            return Trakt['search'].lookup(id, id_type)
+            result = Trakt['search'].lookup(id, id_type)
+            if not isinstance(result, list):
+                result = [result]
+            return result

--- a/utilities.py
+++ b/utilities.py
@@ -173,6 +173,20 @@ def getShowDetailsFromKodi(showID, fields):
         logger.debug("getShowDetailsFromKodi(): KeyError: result['tvshowdetails']")
         return None
 
+def getSeasonDetailsFromKodi(seasonID, fields):
+    result = kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetSeasonDetails', 'params': {'seasonid': seasonID, 'properties': fields}, 'id': 1})
+    logger.debug("getSeasonDetailsFromKodi(): %s" % str(result))
+
+    if not result:
+        logger.debug("getSeasonDetailsFromKodi(): Result from Kodi was empty.")
+        return None
+
+    try:
+        return result['seasondetails']
+    except KeyError:
+        logger.debug("getSeasonDetailsFromKodi(): KeyError: result['seasondetails']")
+        return None
+
 # get a single episode from kodi given the id
 def getEpisodeDetailsFromKodi(libraryId, fields):
     result = kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetEpisodeDetails', 'params': {'episodeid': libraryId, 'properties': fields}, 'id': 1})


### PR DESCRIPTION
getIdLookup seems to just return a raw Show object when there is an exact match so your [0] was failing:
```
16:40:20 T:2817518400   FATAL: [script.trakt] service: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'TypeError'>
                                            Error Contents: ("'Show' object does not support indexing",)
                                            Traceback (most recent call last):
                                              File "/home/tknorris/.kodi/addons/script.trakt/service.py", line 61, in _dispatch
                                                self.doManualRating(ratingData)
                                              File "/home/tknorris/.kodi/addons/script.trakt/service.py", line 150, in doManualRating
                                                imdb = dict(globals.traktapi.getIdLookup(data['imdbnumber'], id_type)[0].keys)['imdb']
                                            TypeError: 'Show' object does not support indexing
                                            -->End of Python script error report<--
```
Also, what do you think about changing this logic to just always map to imdb # first and then make the summary / rating calls? In particular, I'm worried that the trakt API doesn't allow tmdb and tvdb id's for summary calls...