### PR TITLE
add id scrobbling

### DIFF
--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -649,3 +649,7 @@ msgstr ""
 msgctxt "#32163"
 msgid "User"
 msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -22,6 +22,7 @@
 		<setting id="scrobble_movie" type="bool" label="32012" default="true"/>
 		<setting id="scrobble_episode" type="bool" label="32013" default="true"/>
 		<setting id="scrobble_notification" type="bool" label="32014" default="false"/>
+		<setting id="scrobble_fallback" type="bool" label="32164" default="true"/>
 	</category>
 	<category label="32045"><!-- Synchronize -->
 		<setting label="32054" type="lsep"/><!-- Service -->

--- a/scrobbler.py
+++ b/scrobbler.py
@@ -78,6 +78,10 @@ class Scrobbler():
         self.curVideoInfo = None
         self.videosToRate = []
 
+        if not utilities.getSettingAsBool('scrobble_fallback') and 'id' not in self.curVideo and 'video_ids' not in self.curVideo:
+            logger.debug('Aborting scrobble to avoid fallback: %s' % (self.curVideo))
+            return
+             
         if 'type' in self.curVideo:
             logger.debug("Watching: %s" % self.curVideo['type'])
             if not xbmc.Player().isPlayingVideo():
@@ -110,6 +114,8 @@ class Scrobbler():
             if utilities.isMovie(self.curVideo['type']):
                 if 'id' in self.curVideo:
                     self.curVideoInfo = utilities.kodiRpcToTraktMediaObject('movie', utilities.getMovieDetailsFromKodi(self.curVideo['id'], ['imdbnumber', 'title', 'year', 'file', 'lastplayed', 'playcount']))
+                elif 'video_ids' in self.curVideo:
+                    self.curVideoInfo = {'ids': self.curVideo['video_ids']}
                 elif 'title' in self.curVideo and 'year' in self.curVideo:
                     self.curVideoInfo = {'title': self.curVideo['title'], 'year': self.curVideo['year']}
 
@@ -131,6 +137,9 @@ class Scrobbler():
                         self.isPlaying = False
                         self.watchedTime = 0
                         return
+                elif 'video_ids' in self.curVideo and 'season' in self.curVideo and 'episode' in self.curVideo:
+                    self.curVideoInfo = {'season': self.curVideo['season'], 'number': self.curVideo['episode']}
+                    self.traktShowSummary = {'ids': self.curVideo['video_ids']}
                 elif 'title' in self.curVideo and 'season' in self.curVideo and 'episode' in self.curVideo:
                     self.curVideoInfo = {'title': self.curVideo['title'], 'season': self.curVideo['season'],
                                          'number': self.curVideo['episode']}
@@ -153,7 +162,7 @@ class Scrobbler():
             if utilities.getSettingAsBool('scrobble_movie') or utilities.getSettingAsBool('scrobble_episode'):
                 result = self.__scrobble('start')
             elif utilities.getSettingAsBool('rate_movie') and utilities.isMovie(self.curVideo['type']):
-                result = {'movie':self.traktapi.getMovieSummary(self.curVideoInfo['ids']['imdb']).to_dict()}
+                result = {'movie': self.traktapi.getMovieSummary(self.curVideoInfo['ids']['imdb']).to_dict()}
             elif utilities.getSettingAsBool('rate_episode') and utilities.isEpisode(self.curVideo['type']):
                 data, id_type = utilities.parseIdToTraktIds(str(self.traktShowSummary['ids']['tvdb']), self.curVideo['type'])
                 ids = self.traktapi.getIdLookup(data[id_type], id_type)


### PR DESCRIPTION
This adds the code to pick up the script.trakt.ids property and pass it to scrobble if it exists. It also adds to the title/year fallback setting (default = True). I tested movies and episodes with script.trakt.ids set and not set.