### PR TITLE
Fix for duplicate episode watched status sync

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.trakt" name="Trakt" version="3.0.2~beta2" provider-name="Trakt.tv">
+<addon id="script.trakt" name="Trakt" version="3.0.2~beta3" provider-name="Trakt.tv">
 	<requires>
 		<import addon="xbmc.python" version="2.14.0"/>
 		<import addon="script.module.simplejson" version="3.3.0"/>

--- a/utilities.py
+++ b/utilities.py
@@ -492,7 +492,7 @@ def parseIdToTraktIds(id, type):
     elif id.isdigit() and isMovie(type):
         data['tmdb'] = id
         id_type = 'tmdb'
-    elif id.isdigit() and isEpisode(type):
+    elif id.isdigit() and (isEpisode(type) or isShow(type)):
         data['tvdb'] = id
         id_type = 'tvdb'
     return data, id_type

--- a/utilities.py
+++ b/utilities.py
@@ -331,7 +331,7 @@ def findEpisodeMatchInList(id, seasonNumber, episodeNumber, list, idType):
     return {}
 
 def kodiRpcToTraktMediaObject(type, data, mode='collected'):
-    if type == 'tvshow':
+    if type == 'show':
         id = data.pop('imdbnumber')
         data['ids'], _ = parseIdToTraktIds(id, type)
         del(data['label'])
@@ -393,7 +393,7 @@ def kodiRpcToTraktMediaObjects(data, mode='collected'):
 
         # reformat show array
         for show in shows:
-            kodiRpcToTraktMediaObject('tvshow', show, mode)
+            kodiRpcToTraktMediaObject('show', show, mode)
         return shows
 
     elif 'episodes' in data:


### PR DESCRIPTION
I checked to see if kodiRpcToTraktMediaObject was called for tv shows from anywhere else and I don't think it is. So, we should be good. I tested on my main htpc to make sure this stopped the duplicate syncs.