### PR TITLE
Fix scrobbling with video_ids but not title/year. Minor pythonic fixes

### DIFF
--- a/scrobbler.py
+++ b/scrobbler.py
@@ -138,7 +138,7 @@ class Scrobbler():
                         self.watchedTime = 0
                         return
                 elif 'video_ids' in self.curVideo and 'season' in self.curVideo and 'episode' in self.curVideo:
-                    self.curVideoInfo = {'title': self.curVideo['title'], 'season': self.curVideo['season'], 'number': self.curVideo['episode']}
+                    self.curVideoInfo = {'season': self.curVideo['season'], 'number': self.curVideo['episode']}
                     self.traktShowSummary = {'ids': self.curVideo['video_ids']}
                 elif 'title' in self.curVideo and 'season' in self.curVideo and 'episode' in self.curVideo:
                     self.curVideoInfo = {'title': self.curVideo['title'], 'season': self.curVideo['season'],
@@ -176,14 +176,14 @@ class Scrobbler():
             if utilities.isMovie(self.curVideo['type']) and utilities.getSettingAsBool('rate_movie'):
                 # pre-get summary information, for faster rating dialog.
                 logger.debug("Movie rating is enabled, pre-fetching summary information.")
+                self.curVideoInfo = result['movie']
                 self.curVideoInfo['user'] = {'ratings': self.traktapi.getMovieRatingForUser(result['movie']['ids']['trakt'], 'trakt')}
-                self.curVideoInfo['ids'] = result['movie']['ids']
             elif utilities.isEpisode(self.curVideo['type']) and utilities.getSettingAsBool('rate_episode'):
                 # pre-get summary information, for faster rating dialog.
                 logger.debug("Episode rating is enabled, pre-fetching summary information.")
+                self.curVideoInfo = result['episode']
                 self.curVideoInfo['user'] = {'ratings': self.traktapi.getEpisodeRatingForUser(result['show']['ids']['trakt'],
                                                                                               self.curVideoInfo['season'], self.curVideoInfo['number'], 'trakt')}
-                self.curVideoInfo['ids'] = result['episode']['ids']
             logger.debug('Pre-Fetch result: %s; Info: %s' % (result, self.curVideoInfo))
 
     def playbackResumed(self):
@@ -265,7 +265,7 @@ class Scrobbler():
 
             response = self.traktapi.scrobbleEpisode(self.traktShowSummary, self.curVideoInfo, watchedPercent, status)
 
-            if not response is None:
+            if response is not None:
                 self.__scrobbleNotification(response)
                 logger.debug("Scrobble response: %s" % str(response))
                 return response

--- a/service.py
+++ b/service.py
@@ -425,16 +425,16 @@ class traktPlayer(xbmc.Player):
                     data['showtitle'] = showtitle
                     data['title'] = xbmc.getInfoLabel('VideoPlayer.Title')
                     if year.isdigit():
-                        data['year'] = year
+                        data['year'] = int(year)
                     logger.debug("[traktPlayer] onPlayBackStarted() - Playing a non-library 'episode' - %s - S%02dE%02d - %s." % (data['showtitle'], data['season'], data['episode'], data['title']))
                 elif (year or video_ids) and not season and not showtitle:
                     # we have a year or video_id and no season/showtitle info, enough for a movie
                     self.type = 'movie'
                     data['type'] = 'movie'
-                    if year:
+                    if year.isdigit():
                         data['year'] = int(year)
                     data['title'] = xbmc.getInfoLabel('VideoPlayer.Title')
-                    logger.debug("[traktPlayer] onPlayBackStarted() - Playing a non-library 'movie' - %s (%s)." % (data['title'], data['year'] if 'year' in data else ''))
+                    logger.debug("[traktPlayer] onPlayBackStarted() - Playing a non-library 'movie' - %s (%s)." % (data['title'], data.get('year', 'NaN')))
                 elif showtitle:
                     title, season, episode = utilities.regex_tvshow(False, showtitle)
                     data['type'] = 'episode'

--- a/utilities.py
+++ b/utilities.py
@@ -145,18 +145,20 @@ def checkExclusion(fullpath):
     return False
 
 def getFormattedItemName(type, info):
-    s = None
-    if isShow(type) and 'title' in info:
-        s = info['title']
-    elif isEpisode(type) and 'title' in info and 'season' in info and 'number' in info:
-            s = "S%02dE%02d - %s" % (info['season'], info['number'], info['title'])
-    elif isSeason(type) and 'title' in info:
-        if info['season'] > 0:
-            s = "%s - Season %d" % (info['title'], info['season'])
-        else:
-            s = "%s - Specials" % info['title']
-    elif isMovie(type and 'title' in info and 'year' in info):
-        s = "%s (%s)" % (info['title'], info['year'])
+    try:
+        if isShow(type):
+            s = info['title']
+        elif isEpisode(type):
+                s = "S%02dE%02d - %s" % (info['season'], info['number'], info['title'])
+        elif isSeason(type):
+            if info['season'] > 0:
+                s = "%s - Season %d" % (info['title'], info['season'])
+            else:
+                s = "%s - Specials" % info['title']
+        elif isMovie(type):
+            s = "%s (%s)" % (info['title'], info['year'])
+    except KeyError:
+        s = ''
     return s.encode('utf-8', 'ignore')
 
 def getShowDetailsFromKodi(showID, fields):


### PR DESCRIPTION
This should fix the video_id scrobbling issue. I also noticed a few non-pythonic changes in related commits that I changed. 

The basic idea of this change is that the preFetch() call overrides the self.curVideoInfo() with the data returned from the scrobble or the summary calls to be used later. I tested movie and episodes scrobbling and ratings using video_ids.