### PR TITLE
Increase number of excludable paths from 3 to 12

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -17,6 +17,24 @@
 		<setting id="ExcludePath2" type="folder" source="video" label="32020" default="" visible= "eq(-1,true)" enable="eq(-1,true)" />
 		<setting id="ExcludePathOption3" type="bool" label="32019" default="false" visible= "eq(-2,true)" enable="eq(-2,true)" />
 		<setting id="ExcludePath3" type="folder" source="video" label="32020" default="" visible= "eq(-1,true)" enable="eq(-1,true)" />
+		<setting id="ExcludePathOption4" type="bool" label="32019" default="false" visible= "eq(-2,true)" enable="eq(-2,true)" />
+		<setting id="ExcludePath4" type="folder" source="video" label="32020" default="" visible= "eq(-1,true)" enable="eq(-1,true)" />
+		<setting id="ExcludePathOption5" type="bool" label="32019" default="false" visible= "eq(-2,true)" enable="eq(-2,true)" />
+		<setting id="ExcludePath5" type="folder" source="video" label="32020" default="" visible= "eq(-1,true)" enable="eq(-1,true)" />
+		<setting id="ExcludePathOption6" type="bool" label="32019" default="false" visible= "eq(-2,true)" enable="eq(-2,true)" />
+		<setting id="ExcludePath6" type="folder" source="video" label="32020" default="" visible= "eq(-1,true)" enable="eq(-1,true)" />
+		<setting id="ExcludePathOption7" type="bool" label="32019" default="false" visible= "eq(-2,true)" enable="eq(-2,true)" />
+		<setting id="ExcludePath7" type="folder" source="video" label="32020" default="" visible= "eq(-1,true)" enable="eq(-1,true)" />
+		<setting id="ExcludePathOption8" type="bool" label="32019" default="false" visible= "eq(-2,true)" enable="eq(-2,true)" />
+		<setting id="ExcludePath8" type="folder" source="video" label="32020" default="" visible= "eq(-1,true)" enable="eq(-1,true)" />
+		<setting id="ExcludePathOption9" type="bool" label="32019" default="false" visible= "eq(-2,true)" enable="eq(-2,true)" />
+		<setting id="ExcludePath9" type="folder" source="video" label="32020" default="" visible= "eq(-1,true)" enable="eq(-1,true)" />
+		<setting id="ExcludePathOption10" type="bool" label="32019" default="false" visible= "eq(-2,true)" enable="eq(-2,true)" />
+		<setting id="ExcludePath10" type="folder" source="video" label="32020" default="" visible= "eq(-1,true)" enable="eq(-1,true)" />
+		<setting id="ExcludePathOption11" type="bool" label="32019" default="false" visible= "eq(-2,true)" enable="eq(-2,true)" />
+		<setting id="ExcludePath11" type="folder" source="video" label="32020" default="" visible= "eq(-1,true)" enable="eq(-1,true)" />
+		<setting id="ExcludePathOption12" type="bool" label="32019" default="false" visible= "eq(-2,true)" enable="eq(-2,true)" />
+		<setting id="ExcludePath12" type="folder" source="video" label="32020" default="" visible= "eq(-1,true)" enable="eq(-1,true)" />
 	</category>
 	<category label="32011"><!-- Scrobbling -->
 		<setting id="scrobble_movie" type="bool" label="32012" default="true"/>

--- a/utilities.py
+++ b/utilities.py
@@ -129,20 +129,64 @@ def checkExclusion(fullpath):
         if fullpath.find(ExcludePath) > -1:
             logger.debug("checkExclusion(): Video is from location, which is currently set as excluded path 1.")
             return True
-
     ExcludePath2 = getSetting('ExcludePath2')
     if ExcludePath2 != "" and getSettingAsBool('ExcludePathOption2'):
         if fullpath.find(ExcludePath2) > -1:
             logger.debug("checkExclusion(): Video is from location, which is currently set as excluded path 2.")
             return True
-
     ExcludePath3 = getSetting('ExcludePath3')
     if ExcludePath3 != "" and getSettingAsBool('ExcludePathOption3'):
         if fullpath.find(ExcludePath3) > -1:
             logger.debug("checkExclusion(): Video is from location, which is currently set as excluded path 3.")
             return True
+    ExcludePath4 = getSetting('ExcludePath4')
+    if ExcludePath4 != "" and getSettingAsBool('ExcludePathOption'):
+        if fullpath.find(ExcludePath4) > -1:
+            logger.debug("checkExclusion(): Video is from location, which is currently set as excluded path 4.")
+            return True
+    ExcludePath5 = getSetting('ExcludePath5')
+    if ExcludePath5 != "" and getSettingAsBool('ExcludePathOption2'):
+        if fullpath.find(ExcludePath5) > -1:
+            logger.debug("checkExclusion(): Video is from location, which is currently set as excluded path 5.")
+            return True
+    ExcludePath6 = getSetting('ExcludePath6')
+    if ExcludePath6 != "" and getSettingAsBool('ExcludePathOption3'):
+        if fullpath.find(ExcludePath6) > -1:
+            logger.debug("checkExclusion(): Video is from location, which is currently set as excluded path 6.")
+            return True
+    ExcludePath7 = getSetting('ExcludePath7')
+    if ExcludePath7 != "" and getSettingAsBool('ExcludePathOption'):
+        if fullpath.find(ExcludePath7) > -1:
+            logger.debug("checkExclusion(): Video is from location, which is currently set as excluded path 7.")
+            return True
+    ExcludePath8 = getSetting('ExcludePath8')
+    if ExcludePath8 != "" and getSettingAsBool('ExcludePathOption2'):
+        if fullpath.find(ExcludePath8) > -1:
+            logger.debug("checkExclusion(): Video is from location, which is currently set as excluded path 8.")
+            return True
+    ExcludePath9 = getSetting('ExcludePath9')
+    if ExcludePath9 != "" and getSettingAsBool('ExcludePathOption3'):
+        if fullpath.find(ExcludePath9) > -1:
+            logger.debug("checkExclusion(): Video is from location, which is currently set as excluded path 9.")
+            return True
+    ExcludePath10 = getSetting('ExcludePath10')
+    if ExcludePath10 != "" and getSettingAsBool('ExcludePathOption'):
+        if fullpath.find(ExcludePath10) > -1:
+            logger.debug("checkExclusion(): Video is from location, which is currently set as excluded path 10.")
+            return True
+    ExcludePath11 = getSetting('ExcludePath11')
+    if ExcludePath11 != "" and getSettingAsBool('ExcludePathOption2'):
+        if fullpath.find(ExcludePath11) > -1:
+            logger.debug("checkExclusion(): Video is from location, which is currently set as excluded path 11.")
+            return True
+    ExcludePath12 = getSetting('ExcludePath12')
+    if ExcludePath12 != "" and getSettingAsBool('ExcludePathOption3'):
+        if fullpath.find(ExcludePath12) > -1:
+            logger.debug("checkExclusion(): Video is from location, which is currently set as excluded path 12.")
+            return True
 
     return False
+
 
 def getFormattedItemName(type, info):
     try:


### PR DESCRIPTION
Three excludable paths are too few for my personal use (gf uses same Kodi, but I don't want her shows to be synced), so I increased the number to 12.

Tested it and it seems to work.
