### PR TITLE
Use Text Query API call for alt titles

### DIFF
--- a/scrobbler.py
+++ b/scrobbler.py
@@ -264,7 +264,27 @@ class Scrobbler():
                 adjustedDuration = int(self.videoDuration / self.curVideo['multi_episode_count'])
                 watchedPercent = ((self.watchedTime - (adjustedDuration * self.curMPEpisode)) / adjustedDuration) * 100
 
+            logger.debug("scrobble sending show object: %s" % str(self.traktShowSummary))
             response = self.traktapi.scrobbleEpisode(self.traktShowSummary, self.curVideoInfo, watchedPercent, status)
+            
+            # If there is an empty response, the reason might be that the title we have isn't the actual show title,
+            # but rather an alternative title. To handle this case, call the Trakt search function.
+            if response is None:
+                logger.debug("Searching for show title: %s" % self.traktShowSummary['title'])
+                # This text query API is basically the same as searching on the website. Works with alternative 
+                # titles, unlike the scrobble function.
+                newResp = self.traktapi.getTextQuery(self.traktShowSummary['title'], "show", None)
+                if not newResp:
+                    logger.debug("Empty Response from getTextQuery, giving up")
+                else:
+                    logger.debug("Got Response from getTextQuery: %s" % str(newResp))
+                    # We got something back. Have to assume the first show found is the right one; if there's more than
+                    # one, there's no way to know which to use. Pull the primary title from the response (and the year,
+                    # just because it's there).
+                    showObj = {'title': newResp[0].title, 'year': newResp[0].year}
+                    logger.debug("scrobble sending getTextQuery first show object: %s" % str(showObj))
+                    # Now we can attempt the scrobble again, using the primary title this time.
+                    response = self.traktapi.scrobbleEpisode(showObj, self.curVideoInfo, watchedPercent, status)
 
             if response is not None:
                 self.__scrobbleNotification(response)

--- a/scrobbler.py
+++ b/scrobbler.py
@@ -118,6 +118,9 @@ class Scrobbler():
                     self.curVideoInfo = {'ids': self.curVideo['video_ids']}
                 elif 'title' in self.curVideo and 'year' in self.curVideo:
                     self.curVideoInfo = {'title': self.curVideo['title'], 'year': self.curVideo['year']}
+                else:
+                    logger.debug("Couldn't set curVideoInfo for movie type")
+                logger.debug("Movie type, curVideoInfo: %s" % self.curVideoInfo)
 
             elif utilities.isEpisode(self.curVideo['type']):
                 if 'id' in self.curVideo:
@@ -152,9 +155,15 @@ class Scrobbler():
 
                     if 'year' in self.curVideo:
                         self.traktShowSummary['year'] = self.curVideo['year']
+                else:
+                    logger.debug("Couldn't set curVideoInfo/traktShowSummary for episode type")
 
                 if 'multi_episode_count' in self.curVideo and self.curVideo['multi_episode_count'] > 1:
                     self.isMultiPartEpisode = True
+
+                logger.debug("Episode type, curVideoInfo: %s" % self.curVideoInfo)
+                logger.debug("Episode type, traktShowSummary: %s" % self.traktShowSummary)
+
 
             self.isPlaying = True
             self.isPaused = False

--- a/traktapi.py
+++ b/traktapi.py
@@ -283,6 +283,13 @@ class traktAPI(object):
                 result = [result]
             return result
 
+    def getTextQuery(self, query, type, year):
+        with Trakt.configuration.http(retry=True):
+            result = Trakt['search'].query(query, type, year)
+            if result and not isinstance(result, list):
+                result = [result]
+            return result
+
     def getUser(self):
         with Trakt.configuration.oauth.from_response(self.authorization):
             with Trakt.configuration.http(retry=True):


### PR DESCRIPTION
If scrobbling an episode of a show initially fails, make a call to the
Text Query API using the show title. Unlike scrobbling, Text Query will
find alternative titles. If it returns something, try scrobbling again
with the result.
