### PR TITLE
Fix ratings window not popping up when playing from addons

### DIFF
--- a/scrobbler.py
+++ b/scrobbler.py
@@ -163,15 +163,16 @@ class Scrobbler():
             if utilities.getSettingAsBool('scrobble_movie') or utilities.getSettingAsBool('scrobble_episode'):
                 result = self.__scrobble('start')
             elif utilities.getSettingAsBool('rate_movie') and utilities.isMovie(self.curVideo['type']) and 'ids' in self.curVideoInfo:
-                result = {'movie': self.traktapi.getMovieSummary(utilities.best_id(self.curVideoInfo['ids'])).to_dict()}
-                result['movie']['movieid'] = self.curVideo['id']
+                best_id = utilities.best_id(self.curVideoInfo['ids'])
+                result = {'movie': self.traktapi.getMovieSummary(best_id).to_dict()}
+                if 'id' in self.curVideo: result['movie']['movieid'] = self.curVideo['id']
             elif utilities.getSettingAsBool('rate_episode') and utilities.isEpisode(self.curVideo['type']) and 'ids' in self.traktShowSummary:
                 best_id = utilities.best_id(self.traktShowSummary['ids'])
                 result = {'show': self.traktapi.getShowSummary(best_id).to_dict(),
                           'episode': self.traktapi.getEpisodeSummary(best_id, self.curVideoInfo['season'],
                                                                      self.curVideoInfo['number']).to_dict()}
                 result['episode']['season'] = self.curVideoInfo['season']
-                result['episode']['episodeid']= self.curVideo['id']
+                if 'id' in self.curVideo: result['episode']['episodeid'] = self.curVideo['id']
 
             self.__preFetchUserRatings(result)
 

--- a/utilities.py
+++ b/utilities.py
@@ -568,14 +568,14 @@ def getMediaType():
 
 def best_id(ids):
     if 'trakt' in ids:
-        return ids['trakt'], 'trakt'
+        return ids['trakt']
     elif 'imdb' in ids:
-        return ids['imdb'], 'imdb'
+        return ids['imdb']
     elif 'tmdb' in ids:
-        return ids['tmdb'], 'tmdb'
+        return ids['tmdb']
     elif 'tvdb' in ids:
-        return ids['tvdb'], 'tvdb'
+        return ids['tvdb']
     elif 'tvrage' in ids:
-        return ids['tvrage'], 'tvrage'
+        return ids['tvrage']
     elif 'slug' in ids:
-        return ids['slug'], 'slug'
+        return ids['slug']


### PR DESCRIPTION
This should fix this issue: https://github.com/trakt/script.trakt/issues/269

To double check my changes though:

It looks like you changed how best_id() worked to also return the id type of the best id that was found, but didn't update the existing calls to account for that change. The weird thing though is I couldn't find anywhere new that best_id() was called from? Let me know if you'd rather me change best_id back to the way it was and change the calls back to the way they were before they were broken.

Also, self.curVideo['id'] only exists when playing from the library but those two elif sections should only be executed when playing from an addon so I don't think I broke anything removing them. Let me know if you had some other intent with that change that I'm not aware of and I'll fix it.