### PR TITLE
don't throw exception is season & episode are not integers

### DIFF
--- a/service.py
+++ b/service.py
@@ -450,10 +450,9 @@ class traktPlayer(xbmc.Player):
                     elif showtitle:
                         title, season, episode = utilities.regex_tvshow(False, showtitle)
                         data['type'] = 'episode'
-                        data['season'] = int(season)
-                        data['episode'] = int(episode)
-                        data['showtitle'] = title
-                        data['title'] = title
+                        data['season'] = season
+                        data['episode'] = episode
+                        data['title'] = data['showtitle'] = title
                         logger.debug("[traktPlayer] onPlayBackStarted() - Title: %s, showtitle: %s, season: %d, episode: %d" % (title, showtitle, season, episode))
                     else:
                         logger.debug("[traktPlayer] onPlayBackStarted() - Non-library file, not enough data for scrobbling, skipping.")


### PR DESCRIPTION
Hey, someone sent me a log w/ these errors in it so I thought I'd throw in a quick fix before your next update. This just sets season and episode to 0 if they aren't ints rather than raising an exception.