### PR TITLE
Residual fix for ValueError: (22, 'Invalid argument') issue

### DIFF
--- a/utilities.py
+++ b/utilities.py
@@ -501,8 +501,8 @@ def convertUtcToDateTime(toConvert):
             utc = naive.replace(tzinfo=tzutc())
             local = utc.astimezone(tzlocal())
         except ValueError:
-		    logger.debug('convertUtcToDateTime() ValueError: movie/show was collected/watched outside of the unix timespan. Fallback to datetime now')
-		    local = datetime.now()
+            logger.debug('convertUtcToDateTime() ValueError: movie/show was collected/watched outside of the unix timespan. Fallback to datetime now')
+            local = datetime.now()
         return local.strftime(dateFormat)    
     else:
         return toConvert

--- a/utilities.py
+++ b/utilities.py
@@ -482,11 +482,13 @@ def convertDateTimeToUTC(toConvert):
         dateFormat = "%Y-%m-%d %H:%M:%S"
         try: naive = datetime.strptime(toConvert, dateFormat)
         except TypeError: naive = datetime(*(time.strptime(toConvert, dateFormat)[0:6]))
-        if naive.year < 1970 or naive.year > 2038:
-            logger.debug('convertDateTimeToUTC() Movie/show was collected/watched outside of the unix timespan. Fallback to datetime now')
-            naive = datetime.now()
-        local = naive.replace(tzinfo=tzlocal())
-        utc = local.astimezone(tzutc())
+		
+        try:
+            local = naive.replace(tzinfo=tzlocal())
+            utc = local.astimezone(tzutc())
+        except ValueError:
+            logger.debug('convertDateTimeToUTC() ValueError: movie/show was collected/watched outside of the unix timespan. Fallback to datetime utcnow')
+            utc = datetime.utcnow()
         return unicode(utc)
     else:
         return toConvert
@@ -494,13 +496,14 @@ def convertDateTimeToUTC(toConvert):
 def convertUtcToDateTime(toConvert):
     if toConvert:
         dateFormat = "%Y-%m-%d %H:%M:%S"
-        naive = dateutil.parser.parse(toConvert)
-        if naive.year < 1970 or naive.year > 2038:
-            logger.debug('convertUtcToDateTime() Movie/show was collected/watched outside of the unix timespan. Fallback to datetime now')
-            naive = datetime.now()
-        utc = naive.replace(tzinfo=tzutc())
-        local = utc.astimezone(tzlocal())
-        return local.strftime(dateFormat)
+        try:
+            naive = dateutil.parser.parse(toConvert)
+            utc = naive.replace(tzinfo=tzutc())
+            local = utc.astimezone(tzlocal())
+        except ValueError:
+		    logger.debug('convertUtcToDateTime() ValueError: movie/show was collected/watched outside of the unix timespan. Fallback to datetime now')
+		    local = datetime.now()
+        return local.strftime(dateFormat)    
     else:
         return toConvert
 


### PR DESCRIPTION
Addressed ValueError / date outside of unix timespan conversion by wrapping in try-except block. Fixes test case when toConvert is on the very edge of unix timespan and ends up outside after conversion to utc/local

I'm a a novice Python developer (but with professional developer background), so there might be more beautiful / pattern correct solutions.

But it does the trick for my collection. (where i had a few "1970-01-01 00:38" dates... in UTC+1 and UTC+8
