### PR TITLE
Two new options: MythTV PVR Recordings and Secondary Title Lookup

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.trakt" name="Trakt" version="3.1.7" provider-name="Trakt.tv, Razzeee">
+<addon id="script.trakt" name="Trakt" version="3.1.8" provider-name="Trakt.tv, Razzeee">
 	<requires>
         <import addon="xbmc.python" version="2.24.0"/>
         <import addon="script.module.simplejson" version="3.3.0"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 version 3.1.8
   - added MythTV PVR recordings scrobbling, as an option (under Scrobbler in configuration)
+  - added option to perform secondary search for show title by text, if initial scrobble fails
 
 version 3.1.7
   - fixed expired auth tokens not getting refreshed correctly

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+version 3.1.8
+  - added MythTV PVR recordings scrobbling, as an option (under Scrobbler in configuration)
+
 version 3.1.7
   - fixed expired auth tokens not getting refreshed correctly
 

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -721,3 +721,7 @@ msgstr ""
 msgctxt "#32183"
 msgid "Attempt to scrobble MythTV PVR recordings"
 msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -717,3 +717,7 @@ msgstr ""
 msgctxt "#32182"
 msgid "%i show ratings will be updated on Trakt"
 msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -46,6 +46,7 @@
 		<setting id="scrobble_fallback" type="bool" label="32164" default="true"/>
 		<setting id="scrobble_start_offset" type="number" label="32167" default="0"/>
 		<setting id="scrobble_mythtv_pvr" type="bool" label="32183" default="false"/>
+		<setting id="scrobble_secondary_title" type="bool" label="32184" default="false"/>
 	</category>
 	<category label="32045"><!-- Synchronize -->
 		<setting label="32054" type="lsep"/><!-- Service -->

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -45,6 +45,7 @@
 		<setting id="scrobble_notification" type="bool" label="32014" default="false"/>
 		<setting id="scrobble_fallback" type="bool" label="32164" default="true"/>
 		<setting id="scrobble_start_offset" type="number" label="32167" default="0"/>
+		<setting id="scrobble_mythtv_pvr" type="bool" label="32183" default="false"/>
 	</category>
 	<category label="32045"><!-- Synchronize -->
 		<setting label="32054" type="lsep"/><!-- Service -->

--- a/scrobbler.py
+++ b/scrobbler.py
@@ -119,6 +119,9 @@ class Scrobbler():
                     self.curVideoInfo = {'ids': self.curVideo['video_ids']}
                 elif 'title' in self.curVideo and 'year' in self.curVideo:
                     self.curVideoInfo = {'title': self.curVideo['title'], 'year': self.curVideo['year']}
+                else:
+                    logger.debug("Couldn't set curVideoInfo for movie type")
+                logger.debug("Movie type, curVideoInfo: %s" % self.curVideoInfo)
 
             elif utilities.isEpisode(self.curVideo['type']):
                 if 'id' in self.curVideo:
@@ -153,9 +156,14 @@ class Scrobbler():
 
                     if 'year' in self.curVideo:
                         self.traktShowSummary['year'] = self.curVideo['year']
+                else:
+                    logger.debug("Couldn't set curVideoInfo/traktShowSummary for episode type")
 
                 if 'multi_episode_count' in self.curVideo and self.curVideo['multi_episode_count'] > 1:
                     self.isMultiPartEpisode = True
+
+                logger.debug("Episode type, curVideoInfo: %s" % self.curVideoInfo)
+                logger.debug("Episode type, traktShowSummary: %s" % self.traktShowSummary)
 
             self.isPlaying = True
             self.isPaused = False
@@ -275,7 +283,31 @@ class Scrobbler():
                 adjustedDuration = int(self.videoDuration / self.curVideo['multi_episode_count'])
                 watchedPercent = ((self.watchedTime - (adjustedDuration * self.curMPEpisode)) / adjustedDuration) * 100
 
+            logger.debug("scrobble sending show object: %s" % str(self.traktShowSummary))
+            logger.debug("scrobble sending episode object: %s" % str(self.curVideoInfo))
             response = self.traktapi.scrobbleEpisode(self.traktShowSummary, self.curVideoInfo, watchedPercent, status)
+            
+            if (kodiUtilities.getSettingAsBool('scrobble_secondary_title')):
+                logger.debug('[traktPlayer] Setting is enabled to try secondary show title, if necessary.')
+                # If there is an empty response, the reason might be that the title we have isn't the actual show title,
+                # but rather an alternative title. To handle this case, call the Trakt search function.
+                if response is None:
+                    logger.debug("Searching for show title: %s" % self.traktShowSummary['title'])
+                    # This text query API is basically the same as searching on the website. Works with alternative 
+                    # titles, unlike the scrobble function.
+                    newResp = self.traktapi.getTextQuery(self.traktShowSummary['title'], "show", None)
+                    if not newResp:
+                        logger.debug("Empty Response from getTextQuery, giving up")
+                    else:
+                        logger.debug("Got Response from getTextQuery: %s" % str(newResp))
+                        # We got something back. Have to assume the first show found is the right one; if there's more than
+                        # one, there's no way to know which to use. Pull the primary title from the response (and the year,
+                        # just because it's there).
+                        showObj = {'title': newResp[0].title, 'year': newResp[0].year}
+                        logger.debug("scrobble sending getTextQuery first show object: %s" % str(showObj))
+                        # Now we can attempt the scrobble again, using the primary title this time.
+                        response = self.traktapi.scrobbleEpisode(showObj, self.curVideoInfo, watchedPercent, status)
+                    
             if response is not None:
                 self.__scrobbleNotification(response)
                 logger.debug("Scrobble response: %s" % str(response))

--- a/service.py
+++ b/service.py
@@ -9,6 +9,7 @@ import kodiUtilities
 import time
 import xbmcgui
 import json
+import re
 import AddonSignals
 
 from rating import rateMedia
@@ -391,6 +392,7 @@ class traktPlayer(xbmc.Player):
         # only do anything if we're playing a video
         if self.isPlayingVideo():
             # get item data from json rpc
+            logger.debug("[traktPlayer] onPlayBackStarted() - Doing Player.GetItem kodiJsonRequest")
             result = kodiUtilities.kodiJsonRequest({'jsonrpc': '2.0', 'method': 'Player.GetItem', 'params': {'playerid': 1}, 'id': 1})
             if result:
                 logger.debug("[traktPlayer] onPlayBackStarted() - %s" % result)
@@ -409,6 +411,9 @@ class traktPlayer(xbmc.Player):
                 self.type = result['item']['type']
 
                 data = {'action': 'started'}
+
+                if (kodiUtilities.getSettingAsBool('scrobble_mythtv_pvr')):
+                    logger.debug('[traktPlayer] Setting is enabled to try scrobbling mythtv pvr recording, if necessary.')
 
                 # check type of item
                 if 'id' not in result['item']:
@@ -485,7 +490,153 @@ class traktPlayer(xbmc.Player):
                                         logger.debug("[traktPlayer] onPlayBackStarted() - This episode is part of a multi-part episode.")
                                     else:
                                         logger.debug("[traktPlayer] onPlayBackStarted() - This is a single episode.")
-
+                elif (kodiUtilities.getSettingAsBool('scrobble_mythtv_pvr') and self.type == 'unknown' and result['item']['label']):
+                    # If we have label/id but no show type, then this might be a PVR recording.
+                    
+                    # DEBUG INFO: This code is useful when trying to figure out what info is available. Many of the fields
+                    # that you'd expect (TVShowTitle, episode, season, etc) are always blank. In Kodi v15, we got the show
+                    # and episode name in the VideoPlayer label. In v16, that's gone, but the Player.Filename infolabel
+                    # is populated with several interesting things. If these things change in future versions, uncommenting
+                    # this code will hopefully provide some useful info in the debug log.
+                    #logger.debug("[traktPlayer] onPlayBackStarted() - TEMP Checking all videoplayer infolabels.")
+                    #for il in ['VideoPlayer.Time','VideoPlayer.TimeRemaining','VideoPlayer.TimeSpeed','VideoPlayer.Duration','VideoPlayer.Title','VideoPlayer.TVShowTitle','VideoPlayer.Season','VideoPlayer.Episode','VideoPlayer.Genre','VideoPlayer.Director','VideoPlayer.Country','VideoPlayer.Year','VideoPlayer.Rating','VideoPlayer.UserRating','VideoPlayer.Votes','VideoPlayer.RatingAndVotes','VideoPlayer.mpaa','VideoPlayer.IMDBNumber','VideoPlayer.EpisodeName','VideoPlayer.PlaylistPosition','VideoPlayer.PlaylistLength','VideoPlayer.Cast','VideoPlayer.CastAndRole','VideoPlayer.Album','VideoPlayer.Artist','VideoPlayer.Studio','VideoPlayer.Writer','VideoPlayer.Tagline','VideoPlayer.PlotOutline','VideoPlayer.Plot','VideoPlayer.LastPlayed','VideoPlayer.PlayCount','VideoPlayer.VideoCodec','VideoPlayer.VideoResolution','VideoPlayer.VideoAspect','VideoPlayer.AudioCodec','VideoPlayer.AudioChannels','VideoPlayer.AudioLanguage','VideoPlayer.SubtitlesLanguage','VideoPlayer.StereoscopicMode','VideoPlayer.EndTime','VideoPlayer.NextTitle','VideoPlayer.NextGenre','VideoPlayer.NextPlot','VideoPlayer.NextPlotOutline','VideoPlayer.NextStartTime','VideoPlayer.NextEndTime','VideoPlayer.NextDuration','VideoPlayer.ChannelName','VideoPlayer.ChannelNumber','VideoPlayer.SubChannelNumber','VideoPlayer.ChannelNumberLabel','VideoPlayer.ChannelGroup','VideoPlayer.ParentalRating','Player.FinishTime','Player.FinishTime(format)','Player.Chapter','Player.ChapterCount','Player.Time','Player.Time(format)','Player.TimeRemaining','Player.TimeRemaining(format)','Player.Duration','Player.Duration(format)','Player.SeekTime','Player.SeekOffset','Player.SeekOffset(format)','Player.SeekStepSize','Player.ProgressCache','Player.Folderpath','Player.Filenameandpath','Player.StartTime','Player.StartTime(format)','Player.Title','Player.Filename']:
+                    #    logger.debug("[traktPlayer] TEMP %s : %s" % (il, xbmc.getInfoLabel(il)))
+                    #for k,v in result.iteritems():
+                    #    logger.debug("[traktPlayer] onPlayBackStarted() - result - %s : %s" % (k,v))
+                    #for k,v in result['item'].iteritems():
+                    #    logger.debug("[traktPlayer] onPlayBackStarted() - result.item - %s : %s" % (k,v))
+                    
+                    # As of Kodi v16 with the MythTV PVR addon, the only way I could find to get the TV show and episode
+                    # info is from the Player.Filename infolabel. It shows up like this:
+                    # ShowName [sXXeYY ](year) EpisodeName, channel, PVRFileName
+                    # The season and episode info may or may not be present. For example:
+                    # Elementary s04e10 (2016) Alma Matters, TV (WWMT-HD), 20160129_030000.pvr
+                    # DC's Legends of Tomorrow (2016) Pilot, Part 2, TV (CW W MI), 20160129_010000.pvr
+                    foundLabel = xbmc.getInfoLabel('Player.Filename')
+                    logger.debug("[traktPlayer] onPlayBackStarted() - Found unknown video type with label: %s. Might be a PVR episode, searching Trakt for it." % foundLabel)
+                    splitLabel = foundLabel.rsplit(", ", 2)
+                    logger.debug("[traktPlayer] onPlayBackStarted() - Post-split of label: %s " % splitLabel)
+                    if len(splitLabel) != 3:
+                        logger.debug("[traktPlayer] onPlayBackStarted() - Label doesn't have the ShowName sXXeYY (year) EpisodeName, channel, PVRFileName format that was expected. Giving up.")
+                        return
+                    foundShowAndEpInfo = splitLabel[0]
+                    logger.debug("[traktPlayer] onPlayBackStarted() - show plus episode info: %s" % foundShowAndEpInfo)
+                    splitShowAndEpInfo = re.split(' (s\d\de\d\d)? ?\((\d\d\d\d)\) ',foundShowAndEpInfo, 1)
+                    logger.debug("[traktPlayer] onPlayBackStarted() - Post-split of show plus episode info: %s " % splitShowAndEpInfo)
+                    if len(splitShowAndEpInfo) != 4:
+                        logger.debug("[traktPlayer] onPlayBackStarted() - Show plus episode info doesn't have the ShowName sXXeYY (year) EpisodeName format that was expected. Giving up.")
+                        return
+                    foundShowName = splitShowAndEpInfo[0]
+                    logger.debug("[traktPlayer] onPlayBackStarted() - using show name: %s" % foundShowName)
+                    foundEpisodeName = splitShowAndEpInfo[3]
+                    logger.debug("[traktPlayer] onPlayBackStarted() - using episode name: %s" % foundEpisodeName)
+                    foundEpisodeYear = splitShowAndEpInfo[2]
+                    logger.debug("[traktPlayer] onPlayBackStarted() - using episode year: %s" % foundEpisodeYear)
+                    epYear = None
+                    try:
+                        epYear = int(foundEpisodeYear)
+                    except ValueError:
+                        epYear = None
+                    logger.debug("[traktPlayer] onPlayBackStarted() - verified episode year: %d" % epYear)
+                    # All right, now we have the show name, episode name, and (maybe) episode year. All good, but useless for
+                    # scrobbling since Trakt only understands IDs, not names.
+                    data['video_ids'] = None
+                    data['season'] = None
+                    data['episode'] = None
+                    data['episodeTitle'] = None
+                    # First thing to try, a text query to the Trakt DB looking for this episode. Note 
+                    # that we can't search for show and episode together, because the Trakt function gets confused and returns nothing.
+                    newResp = globals.traktapi.getTextQuery(foundEpisodeName, "episode", epYear)
+                    if not newResp:
+                        logger.debug("[traktPlayer] onPlayBackStarted() - Empty Response from getTextQuery, giving up")
+                    else:
+                        logger.debug("[traktPlayer] onPlayBackStarted() - Got Response from getTextQuery: %s" % str(newResp))
+                        # We got something back. See if one of the returned values is for the show we're looking for. Often it's
+                        # not, but since there's no way to tell the search which show we want, this is all we can do.
+                        rightResp = None
+                        for thisResp in newResp:
+                            compareShowName = thisResp.show.title
+                            logger.debug("[traktPlayer] onPlayBackStarted() - comparing show name: %s" % compareShowName)
+                            if thisResp.show.title == foundShowName:
+                                logger.debug("[traktPlayer] onPlayBackStarted() - found the right show, using this response")
+                                rightResp = thisResp
+                                break
+                        if rightResp is None:
+                            logger.debug("[traktPlayer] onPlayBackStarted() - Failed to find matching episode/show via text search.")
+                        else:
+                            # OK, now we have a episode object to work with.
+                            self.type = 'episode'
+                            data['type'] = 'episode'
+                            # You'd think we could just use the episode key that Trakt just returned to us, but the scrobbler
+                            # function (see scrobber.py) only understands the show key plus season/episode values.
+                            showKeys = { }
+                            for eachKey in rightResp.show.keys:
+                                showKeys[eachKey[0]] = eachKey[1]
+                            data['video_ids'] = showKeys
+                            # For some reason, the Trakt search call returns the season and episode as an array in the pk field.
+                            # You'd think individual episode and season fields would be better, but whatever.
+                            data['season'] = rightResp.pk[0];
+                            data['episode'] = rightResp.pk[1];
+                    # At this point if we haven't found the episode data yet, the episode-title-text-search method
+                    # didn't work. 
+                    if (not data['season']):
+                        # This text query API is basically the same as searching on the website. Works with alternative 
+                        # titles, unlike the scrobble function. Though we can't use the episode year since that would only
+                        # match the show if we're dealing with season 1.
+                        logger.debug("[traktPlayer] onPlayBackStarted() - Searching for show title via getTextQuery: %s" % foundShowName)
+                        newResp = globals.traktapi.getTextQuery(foundShowName, "show", None)
+                        if not newResp:
+                            logger.debug("[traktPlayer] onPlayBackStarted() - Empty Show Response from getTextQuery, falling back on episode text query")
+                        else:
+                            logger.debug("[traktPlayer] onPlayBackStarted() - Got Show Response from getTextQuery: %s" % str(newResp))
+                            # We got something back. Have to assume the first show found is the right one; if there's more than
+                            # one, there's no way to know which to use. Pull the ids from the show data, and store 'em for scrobbling.
+                            showKeys = { }
+                            for eachKey in newResp[0].keys:
+                                showKeys[eachKey[0]] = eachKey[1]
+                            data['video_ids'] = showKeys
+                            # Now to find the episode. There's no search function to look for an episode within a show, but
+                            # we can get all the episodes and look for the title.
+                            while (not data['season']):
+                                logger.debug("[traktPlayer] onPlayBackStarted() - Querying for all seasons/episodes of this show")
+                                epQueryResp = globals.traktapi.getShowWithAllEpisodesList(data['video_ids']['trakt'])
+                                if not epQueryResp:
+                                    # Nothing returned. Giving up.
+                                    logger.debug("[traktPlayer] onPlayBackStarted() - No response received")
+                                    break;
+                                else:
+                                    # Got the list back. Go through each season.
+                                    logger.debug("[traktPlayer] onPlayBackStarted() - Got response with seasons: %s" % str(epQueryResp))
+                                    for eachSeason in epQueryResp:
+                                        # For each season, check each episode.
+                                        logger.debug("[traktPlayer] onPlayBackStarted() - Processing season: %s" % str(eachSeason))
+                                        for eachEpisodeNumber in eachSeason.episodes:
+                                            thisEpTitle = None
+                                            # Get the title. The try block is here in case the title doesn't exist for some entries.
+                                            try:
+                                                thisEpTitle = eachSeason.episodes[eachEpisodeNumber].title
+                                            except:
+                                                thisEpTitle = None
+                                            logger.debug("[traktPlayer] onPlayBackStarted() - Checking episode number %d with title %s" % (eachEpisodeNumber, thisEpTitle))
+                                            if (foundEpisodeName == thisEpTitle):
+                                                # Found it! Save the data. The scrobbler wants season and episode number. Which for some
+                                                # reason is stored as a pair in the first item in the keys array.
+                                                data['season'] = eachSeason.episodes[eachEpisodeNumber].keys[0][0]
+                                                data['episode'] = eachSeason.episodes[eachEpisodeNumber].keys[0][1]
+                                                # Title too, just for the heck of it. Though it's not actually used.
+                                                data['episodeTitle'] = thisEpTitle
+                                                break
+                                        # If we already found our data, no need to go through the rest of the seasons.
+                                        if (data['season']):
+                                            break;
+                    # Now we've done all we can.
+                    if (data['season']):
+                        # OK, that's everything. Data should be all set for scrobbling.
+                        logger.debug("[traktPlayer] onPlayBackStarted() - Playing a non-library 'episode' : show trakt key %s, season: %d, episode: %d" % (data['video_ids'], data['season'], data['episode']))
+                    else:
+                        # Still no data? Too bad, have to give up.
+                        logger.debug("[traktPlayer] onPlayBackStarted() - Did our best, but couldn't get info for this show and episode. Skipping.")
+                        return;
                 else:
                     logger.debug("[traktPlayer] onPlayBackStarted() - Video type '%s' unrecognized, skipping." % self.type)
                     return

--- a/traktapi.py
+++ b/traktapi.py
@@ -348,7 +348,7 @@ class traktAPI(object):
             return result
 
     def getTextQuery(self, query, type, year):
-        with Trakt.configuration.http(retry=True):
+        with Trakt.configuration.http(retry=True, timeout=90):
             result = Trakt['search'].query(query, type, year)
             if result and not isinstance(result, list):
                 result = [result]

--- a/traktapi.py
+++ b/traktapi.py
@@ -332,6 +332,10 @@ class traktAPI(object):
         with Trakt.configuration.http(retry=True):
             return Trakt['shows'].get(showId)
 
+    def getShowWithAllEpisodesList(self, showId):
+        with Trakt.configuration.http(retry=True, timeout=90):
+            return Trakt['shows'].seasons(showId, extended='episodes')
+
     def getEpisodeSummary(self, showId, season, episode):
         with Trakt.configuration.http(retry=True):
             return Trakt['shows'].episode(showId, season, episode)
@@ -339,6 +343,13 @@ class traktAPI(object):
     def getIdLookup(self, id, id_type):
         with Trakt.configuration.http(retry=True):
             result = Trakt['search'].lookup(id, id_type)
+            if result and not isinstance(result, list):
+                result = [result]
+            return result
+
+    def getTextQuery(self, query, type, year):
+        with Trakt.configuration.http(retry=True):
+            result = Trakt['search'].query(query, type, year)
             if result and not isinstance(result, list):
                 result = [result]
             return result


### PR DESCRIPTION
Added two new options to the Scrobbler function. Both show up in the
configuration under Scrobbler and default to false.

MythTV PVR recordings: attempt to scrobble recordings from the MythTV
PVR add-on, based on the show title/episode name. See comments in
service.py (onPlayBackStarted function) for more info.

Secondary Title Lookup: If scrobbler can't find a show, try the lookup
again using Trakt text search, which works with secondary show titles.
See comments in scrobbler.py (__scrobble function) for more info.
