### PR TITLE
Call Player.GetActivePlayers and use playerId from there on Player.GetItem

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+version 3.1.10
+  - fix scrobling problem when using yatse to start playback
+
 version 3.1.9
   - fallback to only title matching if all else fails
   - updated dependencies

--- a/service.py
+++ b/service.py
@@ -389,8 +389,11 @@ class traktPlayer(xbmc.Player):
         # only do anything if we're playing a video
         if self.isPlayingVideo():
             # get item data from json rpc
+            activePlayers = kodiUtilities.kodiJsonRequest({"jsonrpc": "2.0", "method": "Player.GetActivePlayers", "id": 1})
+            logger.debug("[traktPlayer] onPlayBackStarted() - activePlayers: %s" % activePlayers)
+            playerId = int(activePlayers[0]['playerid'])
             logger.debug("[traktPlayer] onPlayBackStarted() - Doing Player.GetItem kodiJsonRequest")
-            result = kodiUtilities.kodiJsonRequest({'jsonrpc': '2.0', 'method': 'Player.GetItem', 'params': {'playerid': 1}, 'id': 1})
+            result = kodiUtilities.kodiJsonRequest({'jsonrpc': '2.0', 'method': 'Player.GetItem', 'params': {'playerid': playerId}, 'id': 1})
             if result:
                 logger.debug("[traktPlayer] onPlayBackStarted() - %s" % result)
                 # check for exclusion


### PR DESCRIPTION
A fix for https://github.com/trakt/script.trakt/issues/351. 

I think that the bug is in Yatse, since when using that to start video playback, playerId is 0 (audio). When using Kodi itself the playerId is 1 (video).

The fix I made is to get playerId from Player.GetActivePlayers and to use it.

If you want to merge this, go ahead. 
I'll create a bug on Yatse and see if they want to fix this on their end.