### PR TITLE
new exclusions

### DIFF
--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -725,3 +725,11 @@ msgstr ""
 msgctxt "#32184"
 msgid "Attempt secondary show title search"
 msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/resources/lib/kodiUtilities.py
+++ b/resources/lib/kodiUtilities.py
@@ -2,6 +2,7 @@
 #
 
 import xbmc
+import xbmcgui
 import xbmcaddon
 import re
 import sys
@@ -82,6 +83,16 @@ def checkExclusion(fullpath):
     # HTTP exclusion
     if fullpath.startswith(("http://", "https://")) and getSettingAsBool('ExcludeHTTP'):
         logger.debug("checkExclusion(): Video is playing via HTTP source, which is currently set as excluded location.")
+        return True
+        
+    # Plugin exclusion
+    if fullpath.startswith("plugin://") and getSettingAsBool('ExcludePlugin'):
+        logger.debug("checkExclusion(): Video is playing via Plugin source, which is currently set as excluded location.")
+        return True
+
+    # Script exclusion
+    if xbmcgui.Window(10000).getProperty('script.trakt.paused') == 'true' and getSettingAsBool('ExcludeScript'):
+        logger.debug("checkExclusion(): Video is playing via Script source, which is currently set as excluded location.")
         return True
 
     # Path exclusions

--- a/resources/lib/service.py
+++ b/resources/lib/service.py
@@ -685,6 +685,7 @@ class traktPlayer(xbmc.Player):
     # called when kodi stops playing a file
     def onPlayBackEnded(self):
         xbmcgui.Window(10000).clearProperty('script.trakt.ids')
+        xbmcgui.Window(10000).clearProperty('script.trakt.paused')
         if self._playing:
             logger.debug("[traktPlayer] onPlayBackEnded() - %s" % self.isPlayingVideo())
             self._playing = False
@@ -695,6 +696,7 @@ class traktPlayer(xbmc.Player):
     # called when user stops kodi playing a file
     def onPlayBackStopped(self):
         xbmcgui.Window(10000).clearProperty('script.trakt.ids')
+        xbmcgui.Window(10000).clearProperty('script.trakt.paused')
         if self._playing:
             logger.debug("[traktPlayer] onPlayBackStopped() - %s" % self.isPlayingVideo())
             self._playing = False

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -13,6 +13,10 @@
 		<setting id="ExcludeLiveTV" type="bool" label="32017" default="false"/>
 		<!-- HTTP exclusion -->
 		<setting id="ExcludeHTTP" type="bool" label="32018" default="false"/>
+		<!-- Plugin exclusion -->
+		<setting id="ExcludePlugin" type="bool" label="32185" default="false"/>
+		<!-- Script exclusion -->
+		<setting id="ExcludeScript" type="bool" label="32186" default="false"/>
 		<!-- Folder exclusions -->
 		<setting id="ExcludePathOption" type="bool" label="32019" default="false" />
 		<setting id="ExcludePath" type="folder" source="video" label="32020" default="" visible= "eq(-1,true)" enable="eq(-1,true)" />


### PR DESCRIPTION
With upcoming Netflix and Amazon plugins there is a user demand to
disable scrobbling when viewing a plugin source... Also there is a need
from script developers to "Pause" trakt scrobbling when needed. After a
user allows script control "script.trakt.paused" property can temp
disable trakt till the media stops or ends then trakt will clear the
property.