### PR TITLE
Improved id matching for different metadata providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Automatically scrobble all TV episodes and movies you are watching to Trakt.tv! 
 * Custom skin/keymap actions for toggling watched status, and rating (tagging and listing disabled for now)
 
 ### What can be scrobbled?
-This plugin will scrobble local media and most remote streaming content. Local media should be played in Kodi library mode and you should use [TVDb](http://thetvdb.com/) (for tv shows) and [TMDb](http://themoviedb.org) (for movies) as your scrapers. TV shows are identified using their TVDb ID. Movies are identified using the IMDb ID. This allows Trakt to match the correct show or movie more accurately, regardless of the title.
+This plugin will scrobble local media and most remote streaming content. Local media should be played in Kodi library mode. Trakt will attempt to identify the media through different third party IDs available from the metadata. TV shows are identified by TVDb ID or IMDb ID. Movies are identified by TMDb ID or IMDb ID. This allows Trakt to match the correct show or movie more accurately, regardless of the title. The best supported and recommended configuration is to use [TVDb](http://thetvdb.com/) (for tv shows) and [TMDb](http://themoviedb.org) (for movies) as your scrapers.
 
 Remote streaming content will scrobble assuming the metadata is correctly set in Kodi. Add-ons that stream content need to correctly identify TV episodes and movies with as much metadata as possible for Trakt to know what you're watching.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+version 3.1.13
+  - Improved id matching for different metadata providers
+
 version 3.1.12
   - Improved id matching for krypton+
 

--- a/resources/lib/scrobbler.py
+++ b/resources/lib/scrobbler.py
@@ -126,14 +126,14 @@ class Scrobbler():
             elif utilities.isEpisode(self.curVideo['type']):
                 if 'id' in self.curVideo:
                     episodeDetailsKodi = kodiUtilities.getEpisodeDetailsFromKodi(self.curVideo['id'], ['showtitle', 'season', 'episode', 'tvshowid', 'uniqueid', 'file', 'playcount'])
-                    tvdb = episodeDetailsKodi['imdbnumber']
+                    ids = utilities.parseIdToTraktIds(episodeDetailsKodi['imdbnumber'], self.curVideo['type'])[0]
                     title, year = utilities.regex_year(episodeDetailsKodi['showtitle'])
                     if not year:
                         self.traktShowSummary = {'title': episodeDetailsKodi['showtitle'], 'year': episodeDetailsKodi['year']}
                     else:
                         self.traktShowSummary = {'title': title, 'year': year}
-                    if tvdb:
-                        self.traktShowSummary['ids'] = {'tvdb': tvdb}
+                    if ids:
+                        self.traktShowSummary['ids'] = ids
                     self.curVideoInfo = kodiUtilities.kodiRpcToTraktMediaObject('episode', episodeDetailsKodi)
                     if not self.curVideoInfo:  # getEpisodeDetailsFromKodi was empty
                         logger.debug("Episode details from Kodi was empty, ID (%d) seems invalid, aborting further scrobbling of this episode." % self.curVideo['id'])

--- a/resources/lib/syncEpisodes.py
+++ b/resources/lib/syncEpisodes.py
@@ -92,11 +92,8 @@ class SyncEpisodes:
             y = ((i / x) * 8) + 2
             self.sync.UpdateProgress(int(y), line2=kodiUtilities.getString(32097) % (i, x))
 
-            show = {'title': show_col1['title'], 'ids': {}, 'year': show_col1['year'], 'rating': show_col1['rating'],
+            show = {'title': show_col1['title'], 'ids': show_col1['ids'], 'year': show_col1['year'], 'rating': show_col1['rating'],
                     'tvshowid': show_col1['tvshowid'], 'seasons': []}
-
-            if 'ids' in show_col1 and 'tvdb' in show_col1['ids']:
-                show['ids'] = {'tvdb': show_col1['ids']['tvdb']}
 
             data = kodiUtilities.kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetEpisodes', 'params': {'tvshowid': show_col1['tvshowid'], 'properties': ['season', 'episode', 'playcount', 'uniqueid', 'lastplayed', 'file', 'dateadded', 'runtime', 'userrating']}, 'id': 0})
             if not data:
@@ -578,10 +575,10 @@ class SyncEpisodes:
 
                 if show_col2:
                     show = {'title': show_col1['title'], 'ids': {}, 'year': show_col1['year']}
-                    if 'tvdb' in show_col1['ids']:
-                        show['ids'] = {'tvdb': show_col1['ids']['tvdb']}
-                    if 'imdb' in show_col2 and show_col2['imdb']:
-                        show['ids']['imdb'] = show_col2['imdb']
+                    if show_col1['ids']:
+                        show['ids'].update(show_col1['ids'])
+                    if show_col2['ids']:
+                        show['ids'].update(show_col2['ids'])
                     if 'tvshowid' in show_col2:
                         show['tvshowid'] = show_col2['tvshowid']
 
@@ -593,8 +590,8 @@ class SyncEpisodes:
                 else:
                     if not restrict:
                         show = {'title': show_col1['title'], 'ids': {}, 'year': show_col1['year']}
-                        if 'tvdb' in show_col1['ids']:
-                            show['ids'] = {'tvdb': show_col1['ids']['tvdb']}
+                        if show_col1['ids']:
+                            show['ids'].update(show_col1['ids'])
 
                         if rating and 'rating' in show_col1 and show_col1['rating'] != 0:
                             show['rating'] = show_col1['rating']
@@ -683,15 +680,15 @@ class SyncEpisodes:
                     if len(season_diff) > 0:
                         # logger.debug("Season_diff")
                         show = {'title': show_col1['title'], 'ids': {}, 'year': show_col1['year'], 'seasons': []}
-                        if 'tvdb' in show_col1['ids']:
-                            show['ids'] = {'tvdb': show_col1['ids']['tvdb']}
+                        if show_col1['ids']:
+                            show['ids'].update(show_col1['ids'])
+                        if show_col2['ids']:
+                            show['ids'].update(show_col2['ids'])
                         for seasonKey in season_diff:
                             episodes = []
                             for episodeKey in season_diff[seasonKey]:
                                 episodes.append(season_diff[seasonKey][episodeKey])
                             show['seasons'].append({'number': seasonKey, 'episodes': episodes})
-                        if 'imdb' in show_col2 and show_col2['imdb']:
-                            show['ids']['imdb'] = show_col2['imdb']
                         if 'tvshowid' in show_col2:
                             show['tvshowid'] = show_col2['tvshowid']
                         # logger.debug("show %s" % show)
@@ -700,8 +697,8 @@ class SyncEpisodes:
                     if not restrict:
                         if self.__countEpisodes([show_col1]) > 0:
                             show = {'title': show_col1['title'], 'ids': {}, 'year': show_col1['year'], 'seasons': []}
-                            if 'tvdb' in show_col1['ids']:
-                                show['ids'] = {'tvdb': show_col1['ids']['tvdb']}
+                            if show_col1['ids']:
+                                show['ids'].update(show_col1['ids'])
                             for seasonKey in show_col1['seasons']:
                                 episodes = []
                                 for episodeKey in seasonKey['episodes']:


### PR DESCRIPTION
This fixes an sync issue for me with 'House of Cards' as in trakt but 'House of Cards (US)' as in tvdb. Strangely tittle matching was being done instead of id matching. Not all possible ids were effectively used, only tvdb from kodi db whereas I have imdb ids.