### PR TITLE
Fix: Sync progress to library when no runtime info

### DIFF
--- a/resources/lib/syncEpisodes.py
+++ b/resources/lib/syncEpisodes.py
@@ -408,6 +408,10 @@ class SyncEpisodes:
             for show in kodiShowsUpdate['shows']:
                 for season in show['seasons']:
                     for episode in season['episodes']:
+                        # If library item doesn't have a runtime set get it from
+                        # Trakt to avoid later using 0 in runtime * progress_pct.
+                        if not episode['runtime']:
+                            episode['runtime'] = self.sync.traktapi.getEpisodeSummary(show['ids']['trakt'], season['number'], episode['number'], extended='full').runtime
                         episodes.append({'episodeid': episode['ids']['episodeid'], 'progress': episode['progress'], 'runtime': episode['runtime']})
 
             # need to calculate the progress in int from progress in percent from Trakt

--- a/resources/lib/traktapi.py
+++ b/resources/lib/traktapi.py
@@ -331,9 +331,10 @@ class traktAPI(object):
         with Trakt.configuration.http(retry=True, timeout=90):
             return Trakt['shows'].seasons(showId, extended='episodes')
 
-    def getEpisodeSummary(self, showId, season, episode):
+    def getEpisodeSummary(self, showId, season, episode, extended=None):
         with Trakt.configuration.http(retry=True):
-            return Trakt['shows'].episode(showId, season, episode)
+            return Trakt['shows'].episode(showId, season, episode,
+                                          extended=extended)
 
     def getIdLookup(self, id, id_type):
         with Trakt.configuration.http(retry=True):


### PR DESCRIPTION
TVDB does not provide runtime metadata for episodes. If this can not then be
filled by Kodi introspecting the file for the item (e.g. library item that is
a .STRM file) the info label will be `0`. Meaning the resume position set by
Trackt will be `0` as the calculation is `runtime * progress_pct`.

Episode runtime metadata exists in the metadata provided by Trakt for episodes
so this can be queried in these cases to calculate a resume time that is
reasonably accurate.

This depends on fuzeman/trakt.py#69 being merged and propagated to
Razzeee/script.module.trakt