### PR TITLE
Handle episodes without id

### DIFF
--- a/resources/lib/kodiUtilities.py
+++ b/resources/lib/kodiUtilities.py
@@ -132,8 +132,8 @@ def kodiRpcToTraktMediaObject(type, data, mode='collected'):
             episode['ids']['imdb'] = data['uniqueid']['imdb']
         if 'tvdb' in data['uniqueid']:
             episode['ids']['tvdb'] = data['uniqueid']['tvdb']
-        elif 'unknown' in data['uniqueid']:
-            episode['ids']['tvdb'] = utilities.parseIdToTraktIds(data['uniqueid']['unknown'], type)[0]
+                episode['ids'].update(utilities.parseIdToTraktIds(data['uniqueid']['unknown'], type)[0])
+
         if 'lastplayed' in data:
             episode['watched_at'] = utilities.convertDateTimeToUTC(data['lastplayed'])
         if 'dateadded' in data:

--- a/resources/lib/kodiUtilities.py
+++ b/resources/lib/kodiUtilities.py
@@ -124,6 +124,8 @@ def kodiRpcToTraktMediaObject(type, data, mode='collected'):
         episode = {'season': data['season'], 'number': data['episode'], 'title': data['label'],
                    'ids': {'episodeid': data['episodeid']}, 'watched': watched,
                    'plays': plays, 'collected': 1}
+
+        if 'uniqueid' in data:
         if 'tmdb' in data['uniqueid']:
             episode['ids']['tmdb'] = data['uniqueid']['tmdb']
         if 'imdb' in data['uniqueid']:

--- a/resources/lib/kodiUtilities.py
+++ b/resources/lib/kodiUtilities.py
@@ -126,12 +126,13 @@ def kodiRpcToTraktMediaObject(type, data, mode='collected'):
                    'plays': plays, 'collected': 1}
 
         if 'uniqueid' in data:
-        if 'tmdb' in data['uniqueid']:
-            episode['ids']['tmdb'] = data['uniqueid']['tmdb']
-        if 'imdb' in data['uniqueid']:
-            episode['ids']['imdb'] = data['uniqueid']['imdb']
-        if 'tvdb' in data['uniqueid']:
-            episode['ids']['tvdb'] = data['uniqueid']['tvdb']
+            if 'tmdb' in data['uniqueid']:
+                episode['ids']['tmdb'] = data['uniqueid']['tmdb']
+            if 'imdb' in data['uniqueid']:
+                episode['ids']['imdb'] = data['uniqueid']['imdb']
+            if 'tvdb' in data['uniqueid']:
+                episode['ids']['tvdb'] = data['uniqueid']['tvdb']
+            elif 'unknown' in data['uniqueid'] and data['uniqueid']['unknown'] != '':
                 episode['ids'].update(utilities.parseIdToTraktIds(data['uniqueid']['unknown'], type)[0])
 
         if 'lastplayed' in data:


### PR DESCRIPTION
I'm using Sonarr to manage my media and it generates the nfo files for Kodi as it turns out it doesn't include any kind of episode id in the nfo file. After the python api was upgraded to python3 this became a problem, in the old api an empty unknown uniqueid was passed but in the python3 api the entire uniqueid key is missing and crashes the script.

While investigating I also noticed that unknown id-s are parsed under the tvdb key, resulting in ids like this: `{'episodeid': 123, 'tvdb': {'imdb': 'tt123456'}}`. I'm pretty sure this is not the expected behavior.

This pull request:
- Adds a check for the existence of the uniqueid key
- Adds a check for content of the unknown uniqueid
- And fixes the unknown id parsing