### PR TITLE
Fixes trakt fails to find uniqueid for tv episodes

### DIFF
--- a/resources/lib/kodiUtilities.py
+++ b/resources/lib/kodiUtilities.py
@@ -128,9 +128,9 @@ def kodiRpcToTraktMediaObject(type, data, mode='collected'):
         if 'uniqueid' in data:
             if 'tmdb' in data['uniqueid']:
                 episode['ids']['tmdb'] = data['uniqueid']['tmdb']
-            if 'imdb' in data['uniqueid']:
+            elif 'imdb' in data['uniqueid']:
                 episode['ids']['imdb'] = data['uniqueid']['imdb']
-            if 'tvdb' in data['uniqueid']:
+            elif 'tvdb' in data['uniqueid']:
                 episode['ids']['tvdb'] = data['uniqueid']['tvdb']
             elif 'unknown' in data['uniqueid'] and data['uniqueid']['unknown'] != '':
                 episode['ids'].update(utilities.parseIdToTraktIds(data['uniqueid']['unknown'], type)[0])


### PR DESCRIPTION
Hi,

If an unique id based on tmdb cannot be found for tv episodes trakt sync fails. I've seen this on newly imported tv series entry on first time sync. The failture stops the syncronisation of the tv shows causing kodi database to have incomplete tv watch status compared to trakt.tv.

I changed the code to look for either tmdb, imdb, or tvdb and trakt properly sync all tv shows. After this change, all tv series/episodes has been correctly synced.

Tested with: Kodi (19.0-ALPHA1 Git:20200306-80c9184362). Platform: Windows NT x86 64-bit



