### PR TITLE
Fix id handling for manual actions

### DIFF
--- a/resources/lib/kodiUtilities.py
+++ b/resources/lib/kodiUtilities.py
@@ -18,20 +18,26 @@ logger = logging.getLogger(__name__)
 
 REGEX_URL = '(^https?://)(.+)'
 
+
 def notification(header: str, message: str, time=5000, icon=__addon__.getAddonInfo('icon')):
     xbmcgui.Dialog().notification(header, message, icon, time)
+
 
 def showSettings():
     __addon__.openSettings()
 
+
 def getSetting(setting):
     return __addon__.getSetting(setting).strip()
+
 
 def setSetting(setting, value):
     __addon__.setSetting(setting, str(value))
 
+
 def getSettingAsBool(setting):
     return getSetting(setting).lower() == "true"
+
 
 def getSettingAsFloat(setting):
     try:
@@ -39,14 +45,17 @@ def getSettingAsFloat(setting):
     except ValueError:
         return 0
 
+
 def getSettingAsInt(setting):
     try:
         return int(getSettingAsFloat(setting))
     except ValueError:
         return 0
 
+
 def getString(string_id):
     return __addon__.getLocalizedString(string_id)
+
 
 def kodiJsonRequest(params):
     data = json.dumps(params)
@@ -59,10 +68,13 @@ def kodiJsonRequest(params):
             return response['result']
         return None
     except KeyError:
-        logger.warn("[%s] %s" % (params['method'], response['error']['message']))
+        logger.warn("[%s] %s" %
+                    (params['method'], response['error']['message']))
         return None
 
 # check exclusion settings for filename passed as argument
+
+
 def checkExclusion(fullpath: str) -> bool:
 
     if not fullpath:
@@ -70,36 +82,43 @@ def checkExclusion(fullpath: str) -> bool:
 
     # Live TV exclusion
     if fullpath.startswith("pvr://") and getSettingAsBool('ExcludeLiveTV'):
-        logger.debug("checkExclusion(): Video is playing via Live TV, which is currently set as excluded location.")
+        logger.debug(
+            "checkExclusion(): Video is playing via Live TV, which is currently set as excluded location.")
         return True
 
     # HTTP exclusion
     if fullpath.startswith(("http://", "https://")) and getSettingAsBool('ExcludeHTTP'):
-        logger.debug("checkExclusion(): Video is playing via HTTP source, which is currently set as excluded location.")
+        logger.debug(
+            "checkExclusion(): Video is playing via HTTP source, which is currently set as excluded location.")
         return True
 
     # Plugin exclusion
     if fullpath.startswith("plugin://") and getSettingAsBool('ExcludePlugin'):
-        logger.debug("checkExclusion(): Video is playing via Plugin source, which is currently set as excluded location.")
+        logger.debug(
+            "checkExclusion(): Video is playing via Plugin source, which is currently set as excluded location.")
         return True
 
     # Script exclusion
     if xbmcgui.Window(10000).getProperty('script.trakt.paused') == 'true' and getSettingAsBool('ExcludeScript'):
-        logger.debug("checkExclusion(): Video is playing via Script source, which is currently set as excluded location.")
+        logger.debug(
+            "checkExclusion(): Video is playing via Script source, which is currently set as excluded location.")
         return True
 
     # Path exclusions
     ExcludePath = getSetting('ExcludePath')
     if ExcludePath != "" and getSettingAsBool('ExcludePathOption'):
         if fullpath.startswith(ExcludePath):
-            logger.debug("checkExclusion(): Video is from location, which is currently set as excluded path 1.")
+            logger.debug(
+                "checkExclusion(): Video is from location, which is currently set as excluded path 1.")
             return True
 
     found = False
-    for x in range(2,13):
-        found |= utilities.checkExcludePath(getSetting('ExcludePath%i' % x), getSettingAsBool('ExcludePathOption%i' % x), fullpath, x)
+    for x in range(2, 13):
+        found |= utilities.checkExcludePath(getSetting(
+            'ExcludePath%i' % x), getSettingAsBool('ExcludePathOption%i' % x), fullpath, x)
 
     return found
+
 
 def kodiRpcToTraktMediaObject(type, data, mode='collected'):
     if type == 'show':
@@ -136,12 +155,15 @@ def kodiRpcToTraktMediaObject(type, data, mode='collected'):
             if 'tvdb' in data['uniqueid']:
                 episode['ids']['tvdb'] = data['uniqueid']['tvdb']
             elif 'unknown' in data['uniqueid'] and data['uniqueid']['unknown'] != '':
-                episode['ids'].update(utilities.parseIdToTraktIds(data['uniqueid']['unknown'], type)[0])
+                episode['ids'].update(utilities.guessBestTraktId(
+                    data['uniqueid']['unknown'], type)[0])
 
         if 'lastplayed' in data:
-            episode['watched_at'] = utilities.convertDateTimeToUTC(data['lastplayed'])
+            episode['watched_at'] = utilities.convertDateTimeToUTC(
+                data['lastplayed'])
         if 'dateadded' in data:
-            episode['collected_at'] = utilities.convertDateTimeToUTC(data['dateadded'])
+            episode['collected_at'] = utilities.convertDateTimeToUTC(
+                data['dateadded'])
         if 'runtime' in data:
             episode['runtime'] = data['runtime']
         episode['rating'] = data['userrating'] if 'userrating' in data and data['userrating'] > 0 else 0
@@ -156,9 +178,11 @@ def kodiRpcToTraktMediaObject(type, data, mode='collected'):
         if checkExclusion(data.pop('file')):
             return
         if 'lastplayed' in data:
-            data['watched_at'] = utilities.convertDateTimeToUTC(data.pop('lastplayed'))
+            data['watched_at'] = utilities.convertDateTimeToUTC(
+                data.pop('lastplayed'))
         if 'dateadded' in data:
-            data['collected_at'] = utilities.convertDateTimeToUTC(data.pop('dateadded'))
+            data['collected_at'] = utilities.convertDateTimeToUTC(
+                data.pop('dateadded'))
         if data['playcount'] is None:
             data['plays'] = 0
         else:
@@ -175,6 +199,7 @@ def kodiRpcToTraktMediaObject(type, data, mode='collected'):
     else:
         logger.debug('kodiRpcToTraktMediaObject() No valid type')
         return
+
 
 def kodiRpcToTraktMediaObjects(data, mode='collected'):
     if 'tvshows' in data:
@@ -198,7 +223,8 @@ def kodiRpcToTraktMediaObjects(data, mode='collected'):
                 a_episodes[s_no].append(episodeObject)
 
         for episode in a_episodes:
-            seasons.append({'number': episode, 'episodes': a_episodes[episode]})
+            seasons.append(
+                {'number': episode, 'episodes': a_episodes[episode]})
         return seasons
 
     elif 'movies' in data:
@@ -212,11 +238,14 @@ def kodiRpcToTraktMediaObjects(data, mode='collected'):
                 kodi_movies.append(movieObject)
         return kodi_movies
     else:
-        logger.debug('kodiRpcToTraktMediaObjects() No valid key found in rpc data')
+        logger.debug(
+            'kodiRpcToTraktMediaObjects() No valid key found in rpc data')
         return
 
+
 def getShowDetailsFromKodi(showID, fields):
-    result = kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetTVShowDetails', 'params': {'tvshowid': showID, 'properties': fields}, 'id': 1})
+    result = kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetTVShowDetails', 'params': {
+                             'tvshowid': showID, 'properties': fields}, 'id': 1})
     logger.debug("getShowDetailsFromKodi(): %s" % str(result))
 
     if not result:
@@ -226,11 +255,14 @@ def getShowDetailsFromKodi(showID, fields):
     try:
         return result['tvshowdetails']
     except KeyError:
-        logger.debug("getShowDetailsFromKodi(): KeyError: result['tvshowdetails']")
+        logger.debug(
+            "getShowDetailsFromKodi(): KeyError: result['tvshowdetails']")
         return None
 
+
 def getSeasonDetailsFromKodi(seasonID, fields):
-    result = kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetSeasonDetails', 'params': {'seasonid': seasonID, 'properties': fields}, 'id': 1})
+    result = kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetSeasonDetails', 'params': {
+                             'seasonid': seasonID, 'properties': fields}, 'id': 1})
     logger.debug("getSeasonDetailsFromKodi(): %s" % str(result))
 
     if not result:
@@ -240,22 +272,29 @@ def getSeasonDetailsFromKodi(seasonID, fields):
     try:
         return result['seasondetails']
     except KeyError:
-        logger.debug("getSeasonDetailsFromKodi(): KeyError: result['seasondetails']")
+        logger.debug(
+            "getSeasonDetailsFromKodi(): KeyError: result['seasondetails']")
         return None
 
 # get a single episode from kodi given the id
+
+
 def getEpisodeDetailsFromKodi(libraryId, fields):
-    result = kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetEpisodeDetails', 'params': {'episodeid': libraryId, 'properties': fields}, 'id': 1})
+    result = kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetEpisodeDetails', 'params': {
+                             'episodeid': libraryId, 'properties': fields}, 'id': 1})
     logger.debug("getEpisodeDetailsFromKodi(): %s" % str(result))
 
     if not result:
-        logger.debug("getEpisodeDetailsFromKodi(): Result from Kodi was empty.")
+        logger.debug(
+            "getEpisodeDetailsFromKodi(): Result from Kodi was empty.")
         return None
 
-    show_data = getShowDetailsFromKodi(result['episodedetails']['tvshowid'], ['year', 'uniqueid'])
+    show_data = getShowDetailsFromKodi(
+        result['episodedetails']['tvshowid'], ['year', 'uniqueid'])
 
     if not show_data:
-        logger.debug("getEpisodeDetailsFromKodi(): Result from getShowDetailsFromKodi() was empty.")
+        logger.debug(
+            "getEpisodeDetailsFromKodi(): Result from getShowDetailsFromKodi() was empty.")
         return None
 
     result['episodedetails']['show_ids'] = show_data['uniqueid']
@@ -264,12 +303,16 @@ def getEpisodeDetailsFromKodi(libraryId, fields):
     try:
         return result['episodedetails']
     except KeyError:
-        logger.debug("getEpisodeDetailsFromKodi(): KeyError: result['episodedetails']")
+        logger.debug(
+            "getEpisodeDetailsFromKodi(): KeyError: result['episodedetails']")
         return None
 
 # get a single movie from kodi given the id
+
+
 def getMovieDetailsFromKodi(libraryId, fields):
-    result = kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetMovieDetails', 'params': {'movieid': libraryId, 'properties': fields}, 'id': 1})
+    result = kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetMovieDetails', 'params': {
+                             'movieid': libraryId, 'properties': fields}, 'id': 1})
     logger.debug("getMovieDetailsFromKodi(): %s" % str(result))
 
     if not result:
@@ -279,18 +322,26 @@ def getMovieDetailsFromKodi(libraryId, fields):
     try:
         return result['moviedetails']
     except KeyError:
-        logger.debug("getMovieDetailsFromKodi(): KeyError: result['moviedetails']")
+        logger.debug(
+            "getMovieDetailsFromKodi(): KeyError: result['moviedetails']")
         return None
 
-def checkAndConfigureProxy():
-    proxyActive = kodiJsonRequest({'jsonrpc': '2.0', "method":"Settings.GetSettingValue", "params":{"setting":"network.usehttpproxy"}, 'id': 1})['value']
-    proxyType = kodiJsonRequest({'jsonrpc': '2.0', "method":"Settings.GetSettingValue", "params":{"setting":"network.httpproxytype"}, 'id': 1})['value']
 
-    if proxyActive and proxyType == 0: # PROXY_HTTP
-        proxyURL = kodiJsonRequest({'jsonrpc': '2.0', "method":"Settings.GetSettingValue", "params":{"setting":"network.httpproxyserver"}, 'id': 1})['value']
-        proxyPort = str(kodiJsonRequest({'jsonrpc': '2.0', "method":"Settings.GetSettingValue", "params":{"setting":"network.httpproxyport"}, 'id': 1})['value'])
-        proxyUsername = kodiJsonRequest({'jsonrpc': '2.0', "method":"Settings.GetSettingValue", "params":{"setting":"network.httpproxyusername"}, 'id': 1})['value']
-        proxyPassword = kodiJsonRequest({'jsonrpc': '2.0', "method":"Settings.GetSettingValue", "params":{"setting":"network.httpproxypassword"}, 'id': 1})['value']
+def checkAndConfigureProxy():
+    proxyActive = kodiJsonRequest({'jsonrpc': '2.0', "method": "Settings.GetSettingValue", "params": {
+                                  "setting": "network.usehttpproxy"}, 'id': 1})['value']
+    proxyType = kodiJsonRequest({'jsonrpc': '2.0', "method": "Settings.GetSettingValue", "params": {
+                                "setting": "network.httpproxytype"}, 'id': 1})['value']
+
+    if proxyActive and proxyType == 0:  # PROXY_HTTP
+        proxyURL = kodiJsonRequest({'jsonrpc': '2.0', "method": "Settings.GetSettingValue", "params": {
+                                   "setting": "network.httpproxyserver"}, 'id': 1})['value']
+        proxyPort = str(kodiJsonRequest({'jsonrpc': '2.0', "method": "Settings.GetSettingValue", "params": {
+                        "setting": "network.httpproxyport"}, 'id': 1})['value'])
+        proxyUsername = kodiJsonRequest({'jsonrpc': '2.0', "method": "Settings.GetSettingValue", "params": {
+                                        "setting": "network.httpproxyusername"}, 'id': 1})['value']
+        proxyPassword = kodiJsonRequest({'jsonrpc': '2.0', "method": "Settings.GetSettingValue", "params": {
+                                        "setting": "network.httpproxypassword"}, 'id': 1})['value']
 
         if proxyUsername and proxyPassword and proxyURL and proxyPort:
             regexUrl = re.compile(REGEX_URL)
@@ -301,6 +352,7 @@ def checkAndConfigureProxy():
             return proxyURL + ':' + proxyPort
 
     return None
+
 
 def getMediaType():
     if xbmc.getCondVisibility('Container.Content(tvshows)'):
@@ -314,22 +366,27 @@ def getMediaType():
     else:
         return None
 
+
 def getInfoLabelDetails(result):
     type = result['item']['type']
     data = {'action': 'started'}
     # check type of item
     if 'id' not in result['item'] or type == 'channel':
         # do a deeper check to see if we have enough data to perform scrobbles
-        logger.debug("getInfoLabelDetails - Started playing a non-library file, checking available data.")
+        logger.debug(
+            "getInfoLabelDetails - Started playing a non-library file, checking available data.")
         season = int(xbmc.getInfoLabel('VideoPlayer.Season') or '-1')
         episode = int(xbmc.getInfoLabel('VideoPlayer.Episode') or '-1')
-        showtitle = (xbmc.getInfoLabel('VideoPlayer.TVShowTitle') or xbmc.getInfoLabel('VideoPlayer.Title'))
+        showtitle = (xbmc.getInfoLabel('VideoPlayer.TVShowTitle')
+                     or xbmc.getInfoLabel('VideoPlayer.Title'))
         title = xbmc.getInfoLabel('VideoPlayer.EpisodeName')
-        year = (xbmc.getInfoLabel('VideoPlayer.Year') or utilities.regex_year(showtitle)[1])
+        year = (xbmc.getInfoLabel('VideoPlayer.Year')
+                or utilities.regex_year(showtitle)[1])
         video_ids = xbmcgui.Window(10000).getProperty('script.trakt.ids')
         if video_ids:
             data['video_ids'] = json.loads(video_ids)
-        logger.debug("getInfoLabelDetails info - ids: %s, showtitle: %s, Year: %s, Season: %s, Episode: %s" % (video_ids, showtitle, year, season, episode))
+        logger.debug("getInfoLabelDetails info - ids: %s, showtitle: %s, Year: %s, Season: %s, Episode: %s" %
+                     (video_ids, showtitle, year, season, episode))
 
         if season >= 0 and episode > 0 and (showtitle or video_ids):
             # we have season, episode and either a show title or video_ids, can scrobble this as an episode
@@ -341,7 +398,8 @@ def getInfoLabelDetails(result):
             data['title'] = (title or showtitle)
             if year.isdigit():
                 data['year'] = int(year)
-            logger.debug("getInfoLabelDetails - Playing a non-library 'episode' - %s - S%02dE%02d - %s." % (data['showtitle'], data['season'], data['episode'], data['title']))
+            logger.debug("getInfoLabelDetails - Playing a non-library 'episode' - %s - S%02dE%02d - %s." %
+                         (data['showtitle'], data['season'], data['episode'], data['title']))
         elif (year or video_ids) and season < 0 and not title:
             # we have a year or video_id and no season/showtitle info, enough for a movie
             type = 'movie'
@@ -349,7 +407,8 @@ def getInfoLabelDetails(result):
             if year.isdigit():
                 data['year'] = int(year)
             data['title'] = utilities.regex_year(showtitle)[0]
-            logger.debug("getInfoLabelDetails - Playing a non-library 'movie' - %s (%s)." % (data['title'], data.get('year', 'NaN')))
+            logger.debug("getInfoLabelDetails - Playing a non-library 'movie' - %s (%s)." %
+                         (data['title'], data.get('year', 'NaN')))
         elif (showtitle or title):
             title, season, episode = utilities.regex_tvshow(title)
             if season < 0 and episode < 0:
@@ -358,8 +417,10 @@ def getInfoLabelDetails(result):
             data['season'] = season
             data['episode'] = episode
             data['title'] = data['showtitle'] = (title or showtitle)
-            logger.debug("getInfoLabelDetails - Title: %s, showtitle: %s, season: %d, episode: %d" % (title, showtitle, season, episode))
+            logger.debug("getInfoLabelDetails - Title: %s, showtitle: %s, season: %d, episode: %d" %
+                         (title, showtitle, season, episode))
         else:
-            logger.debug("getInfoLabelDetails - Non-library file, not enough data for scrobbling, skipping.")
+            logger.debug(
+                "getInfoLabelDetails - Non-library file, not enough data for scrobbling, skipping.")
             return {}, {}
     return type, data

--- a/resources/lib/scrobbler.py
+++ b/resources/lib/scrobbler.py
@@ -226,11 +226,12 @@ class Scrobbler():
             if kodiUtilities.getSettingAsBool('scrobble_movie') or kodiUtilities.getSettingAsBool('scrobble_episode'):
                 result = self.__scrobble('start')
             elif kodiUtilities.getSettingAsBool('rate_movie') and utilities.isMovie(self.curVideo['type']) and 'ids' in self.curVideoInfo:
-                best_id = utilities.best_id(
+                best_id, id_type = utilities.best_id(
                     self.curVideoInfo['ids'], self.curVideo['type'])
                 result = {'movie': self.traktapi.getMovieSummary(best_id).to_dict()}
             elif kodiUtilities.getSettingAsBool('rate_episode') and utilities.isEpisode(self.curVideo['type']) and 'ids' in self.traktShowSummary:
-                best_id = utilities.best_id(self.traktShowSummary['ids'], self.curVideo['type'])
+                best_id, id_type = utilities.best_id(
+                    self.traktShowSummary['ids'], self.curVideo['type'])
                 result = {'show': self.traktapi.getShowSummary(best_id).to_dict(),
                           'episode': self.traktapi.getEpisodeSummary(best_id, self.curVideoInfo['season'],
                                                                      self.curVideoInfo['number']).to_dict()}

--- a/resources/lib/service.py
+++ b/resources/lib/service.py
@@ -153,17 +153,15 @@ class traktService:
             logger.debug("Getting data for manual %s of %s: video_ids: |%s| dbid: |%s|" % (
                 action, media_type, data.get('video_ids'), data.get('dbid')))
 
-            temp_ids, id_type = utilities.parseIdToTraktIds(
-                str(utilities.best_id(data['video_ids'], media_type)), media_type)
+            best_id, id_type = utilities.best_id(data['video_ids'], media_type)
 
         else:
             logger.debug("Getting data for manual %s of %s: video_id: |%s| dbid: |%s|" % (
                 action, media_type, data.get('video_id'), data.get('dbid')))
 
-            temp_ids, id_type = utilities.parseIdToTraktIds(
+            temp_ids, id_type = utilities.guessBestTraktId(
                 str(data['video_id']), media_type)
-
-        best_id = temp_ids[id_type]
+            best_id = temp_ids[id_type]
 
         if not id_type:
             logger.debug("doManualRating(): Unrecognized id_type: |%s|-|%s|." %
@@ -224,10 +222,7 @@ class traktService:
         media_type = data['media_type']
 
         if utilities.isMovie(media_type):
-            temp_ids, id_type = utilities.parseIdToTraktIds(
-                str(utilities.best_id(data['ids'], media_type)), media_type)
-
-            best_id = temp_ids[id_type]
+            best_id, id_type = utilities.best_id(data['ids'], media_type)
 
             summaryInfo = globals.traktapi.getMovieSummary(
                 best_id).to_dict()
@@ -262,7 +257,7 @@ class traktService:
             s = utilities.getFormattedItemName(media_type, data)
 
             logger.debug("doAddToWatchlist(): '%s - Season %d' trying to add to users watchlist."
-                         % (ids, data['season']))
+                         % (data['ids'], data['season']))
 
             result = globals.traktapi.addToWatchlist(summaryInfo)
             if result:
@@ -286,10 +281,7 @@ class traktService:
         media_type = data['media_type']
 
         if utilities.isMovie(media_type):
-            temp_ids, id_type = utilities.parseIdToTraktIds(
-                str(utilities.best_id(data['ids'], media_type)), media_type)
-
-            best_id = temp_ids[id_type]
+            best_id, id_type = utilities.best_id(data['ids'], media_type)
 
             summaryInfo = globals.traktapi.getMovieSummary(
                 best_id).to_dict()

--- a/resources/lib/utilities.py
+++ b/resources/lib/utilities.py
@@ -6,6 +6,7 @@ import time
 import re
 import logging
 import traceback
+from typing import Tuple
 import dateutil.parser
 from datetime import datetime
 from dateutil.tz import tzutc, tzlocal
@@ -228,7 +229,7 @@ def createError(ex):
     return template.format(type(ex).__name__, ex.args, traceback.format_exc())
 
 
-def parseIdToTraktIds(id, type):
+def guessBestTraktId(id, type) -> Tuple[dict, str]:
     data = {}
     id_type = ''
     if id.startswith("tt"):
@@ -246,19 +247,19 @@ def parseIdToTraktIds(id, type):
     return data, id_type
 
 
-def best_id(ids, type):
+def best_id(ids, type) -> Tuple[str, str]:
     if 'trakt' in ids:
-        return ids['trakt']
+        return ids['trakt'], 'trakt'
     elif 'imdb' in ids and isMovie(type):
-        return ids['imdb']
+        return ids['imdb'], 'imdb'
     elif 'tmdb' in ids:
-        return ids['tmdb']
+        return ids['tmdb'], 'tmdb'
     elif 'tvdb' in ids:
-        return ids['tvdb']
+        return ids['tvdb'], 'tvdb'
     elif 'tvrage' in ids:
-        return ids['tvrage']
+        return ids['tvrage'], 'tvrage'
     elif 'slug' in ids:
-        return ids['slug']
+        return ids['slug'], 'slug'
 
 
 def checkExcludePath(excludePath, excludePathEnabled, fullpath, x):

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -2,6 +2,7 @@
 #
 
 import json
+from typing import Tuple
 import pytest
 from resources.lib import utilities
 
@@ -172,24 +173,25 @@ def test_regex_year_year_2():
     assert utilities.regex_year('ShowTitle')[1] == ''
 
 
-def test_parseIdToTraktIds_IMDB():
-    assert utilities.parseIdToTraktIds('tt1431045', 'movie')[
+def test_guessBestTraktId_IMDB():
+    assert utilities.guessBestTraktId('tt1431045', 'movie')[
         0] == {'imdb': 'tt1431045'}
 
 
-def test_parseIdToTraktIds_TMDB():
-    assert utilities.parseIdToTraktIds('20077', 'movie')[
+def test_guessBestTraktId_TMDB():
+    assert utilities.guessBestTraktId('20077', 'movie')[
         0] == {'tmdb': '20077'}
 
 
-def test_parseIdToTraktIds_Tvdb():
-    assert utilities.parseIdToTraktIds('4346770', 'show')[
+def test_guessBestTraktId_Tvdb():
+    assert utilities.guessBestTraktId('4346770', 'show')[
         0] == {'tvdb': '4346770'}
 
 
 def test_best_id_trakt():
     data = load_params_from_json('tests/fixtures/shows.json')
-    assert utilities.best_id(data[1]['show']['ids'], 'show') == 1395
+    assert utilities.best_id(
+        data[1]['show']['ids'], 'show') == (1395, 'trakt')
 
 
 def test_checkExcludePath_Path_Excluded():
@@ -322,6 +324,7 @@ def test_compareMovies_matchByTitleAndYear_rating_nomatch():
 
     assert utilities.compareMovies(data1, "", True, rating=True) == data1
 
+
 def test_compareMovies_not_matchByTitleAndYear_collected_match():
     data1 = load_params_from_json('tests/fixtures/movies_local.json')
     data2 = load_params_from_json('tests/fixtures/movies_remote.json')
@@ -411,15 +414,22 @@ def test_checkIfNewVersion_old_version_empty():
 
 
 def test_compareShows_matchByTitleAndYear_no_rating():
-    data1 = load_params_from_json('tests/fixtures/compare_shows_local_batman.json')
-    data2 = load_params_from_json('tests/fixtures/compare_shows_remote_batman.json')
+    data1 = load_params_from_json(
+        'tests/fixtures/compare_shows_local_batman.json')
+    data2 = load_params_from_json(
+        'tests/fixtures/compare_shows_remote_batman.json')
 
-    assert utilities.compareShows(data1, data2, True, rating=True) == {"shows": []}
+    assert utilities.compareShows(
+        data1, data2, True, rating=True) == {"shows": []}
+
 
 def test_compareShows_matchByTitleAndYear_rating_changed():
-    data1 = load_params_from_json('tests/fixtures/compare_shows_local_batman_rating.json')
-    data2 = load_params_from_json('tests/fixtures/compare_shows_remote_batman.json')
-    fixture = load_params_from_json('tests/fixtures/compare_shows_compared_batman.json')
+    data1 = load_params_from_json(
+        'tests/fixtures/compare_shows_local_batman_rating.json')
+    data2 = load_params_from_json(
+        'tests/fixtures/compare_shows_remote_batman.json')
+    fixture = load_params_from_json(
+        'tests/fixtures/compare_shows_compared_batman.json')
 
     assert utilities.compareShows(data1, data2, True, rating=True) == fixture
 
@@ -430,7 +440,8 @@ def test_compareShows_not_matchByTitleAndYear_no_rating():
     data2 = load_params_from_json(
         'tests/fixtures/compare_shows_remote_batman.json')
 
-    assert utilities.compareShows(data1, data2, False, rating=True) == {"shows": []}
+    assert utilities.compareShows(
+        data1, data2, False, rating=True) == {"shows": []}
 
 
 def test_compareShows_not_matchByTitleAndYear_rating_changed():
@@ -445,16 +456,21 @@ def test_compareShows_not_matchByTitleAndYear_rating_changed():
 
 
 def test_compareEpisodes_matchByTitleAndYear_no_matches():
-    data1 = load_params_from_json('tests/fixtures/compare_shows_local_batman.json')
-    data2 = load_params_from_json('tests/fixtures/compare_shows_remote_batman.json')
+    data1 = load_params_from_json(
+        'tests/fixtures/compare_shows_local_batman.json')
+    data2 = load_params_from_json(
+        'tests/fixtures/compare_shows_remote_batman.json')
 
     assert utilities.compareEpisodes(data1, data2, True) == {"shows": []}
 
 
 def test_compareEpisodes_matchByTitleAndYear_local_episode_added():
-    data1 = load_params_from_json('tests/fixtures/compare_shows_local_batman.json')
-    data2 = load_params_from_json('tests/fixtures/compare_shows_remote_batman_episode.json')
-    fixture = load_params_from_json('tests/fixtures/compare_shows_batman_episode_to_add.json')
+    data1 = load_params_from_json(
+        'tests/fixtures/compare_shows_local_batman.json')
+    data2 = load_params_from_json(
+        'tests/fixtures/compare_shows_remote_batman_episode.json')
+    fixture = load_params_from_json(
+        'tests/fixtures/compare_shows_batman_episode_to_add.json')
 
     assert utilities.compareEpisodes(data1, data2, True) == fixture
 
@@ -478,16 +494,19 @@ def test_compareEpisodes_not_matchByTitleAndYear_local_episode_added():
 
     assert utilities.compareEpisodes(data1, data2, False) == fixture
 
+
 def test_findMediaObject_not_matchByTitleAndYear_should_not_match():
     data1 = load_params_from_json('tests/fixtures/movies_local_blind.json')
-    data2 = load_params_from_json('tests/fixtures/movies_remote_blind_no_match.json')
+    data2 = load_params_from_json(
+        'tests/fixtures/movies_remote_blind_no_match.json')
 
     assert utilities.findMediaObject(data1, data2, False) == None
 
 
 def test_findMediaObject_not_matchByTitleAndYear_should_match():
     data1 = load_params_from_json('tests/fixtures/movies_local_blind.json')
-    data2 = load_params_from_json('tests/fixtures/movies_remote_blind_match.json')
+    data2 = load_params_from_json(
+        'tests/fixtures/movies_remote_blind_match.json')
 
     assert utilities.findMediaObject(data1, data2, False) == data1
 
@@ -501,21 +520,24 @@ def test_findMediaObject_not_matchByTitleAndYear_add_collection():
 
 def test_findMediaObject_not_matchByTitleAndYear_add_collection_same_year_title_movie_in_collection():
     data1 = load_params_from_json('tests/fixtures/movies_local_chaos.json')
-    data2 = load_params_from_json('tests/fixtures/movies_remote_chaos_match.json')
+    data2 = load_params_from_json(
+        'tests/fixtures/movies_remote_chaos_match.json')
 
     assert utilities.findMediaObject(data1, data2, False) == None
 
 
 def test_findMediaObject_match_by_title_should_match():
     data1 = load_params_from_json('tests/fixtures/movies_local_blind.json')
-    data2 = load_params_from_json('tests/fixtures/movies_remote_blind_no_match.json')
+    data2 = load_params_from_json(
+        'tests/fixtures/movies_remote_blind_no_match.json')
 
     assert utilities.findMediaObject(data1, data2, True) == data2[0]
 
 
 def test_findMediaObject_matchByTitleAndYear_should_match():
     data1 = load_params_from_json('tests/fixtures/movies_local_blind.json')
-    data2 = load_params_from_json('tests/fixtures/movies_remote_blind_match.json')
+    data2 = load_params_from_json(
+        'tests/fixtures/movies_remote_blind_match.json')
 
     assert utilities.findMediaObject(data1, data2, True) == data1
 
@@ -529,18 +551,21 @@ def test_findMediaObject_matchByTitleAndYear_add_collection():
 
 def test_findMediaObject_matchByTitleAndYear_add_collection_same_year_title_movie_in_collection():
     data1 = load_params_from_json('tests/fixtures/movies_local_chaos.json')
-    data2 = load_params_from_json('tests/fixtures/movies_remote_chaos_match.json')
+    data2 = load_params_from_json(
+        'tests/fixtures/movies_remote_chaos_match.json')
 
     assert utilities.findMediaObject(data1, data2, True) == data2[0]
 
 
 def test_countEpisodes1():
-    data1 = load_params_from_json('tests/fixtures/compare_shows_local_batman.json')
+    data1 = load_params_from_json(
+        'tests/fixtures/compare_shows_local_batman.json')
 
     assert utilities.countEpisodes(data1) == 6
 
 
 def test_countEpisodes2():
-    data1 = load_params_from_json('tests/fixtures/compare_shows_remote_batman_episode.json')
+    data1 = load_params_from_json(
+        'tests/fixtures/compare_shows_remote_batman_episode.json')
 
     assert utilities.countEpisodes(data1) == 5


### PR DESCRIPTION
We ignored the correct ids in some cases and ended up thinking
it was a tvdb id, even if we knew better.

Rename parseIdToTraktIds to guessBestTraktId as it's clearer on what it
actially does.  It should only be used, if we don't know which kind
of id we're handling, otherwise it will lead us to loose id types.

Fixes https://github.com/trakt/script.trakt/issues/530