### PR TITLE
Fix empty movie title when year not included in showtitle

### DIFF
--- a/resources/lib/kodiUtilities.py
+++ b/resources/lib/kodiUtilities.py
@@ -441,7 +441,7 @@ def getInfoLabelDetails(result):
             data['type'] = 'movie'
             if year.isdigit():
                 data['year'] = int(year)
-            data['title'] = utilities.regex_year(showtitle)[0]
+            data['title'] = utilities.regex_year(showtitle)[0] or showtitle
             logger.debug("getInfoLabelDetails - Playing a non-library 'movie' - %s (%s)." %
                          (data['title'], data.get('year', 'NaN')))
         elif (showtitle or title):


### PR DESCRIPTION
- Fix issue that is causing movie titles on scrobble to be set to empty string if the `showtitle` does not include the year.
- This means scrobbling is not possible when playing movies from addons like EmbyCon and Netflix.
- Credit for the suggested change to "TeamB" as pointed out [here](https://emby.media/community/index.php?/topic/104533-i-cant-sync-movies-with-trakt-and-think-embycon-might-be-the-problem/&do=findComment&comment=1100587)