### PR TITLE
Fix coverage creation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,22 +8,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.x
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.x
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install python-dateutil pytest mock pytest-cov coverage coveragepy-lcov
+          pip install python-dateutil pytest mock pytest-cov coverage
       - name: Run Test
         run: |
-          py.test --cov coveralls --cov-report term-missing --cov=resources tests/
-      - name: Covert to lcov
-        run: |
-          coveragepy-lcov
+          py.test --cov coveralls --cov-report term-missing --cov-report=lcov --cov=resources tests/
       - name: Coveralls GitHub Action
         uses: coverallsapp/github-action@1.1.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: lcov.info
+          path-to-lcov: coverage.lcov

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 Thumbs.db
 *~
 .cache
+.coverage


### PR DESCRIPTION
Coveragepy-lcov hasn't been ported to python 3.11