### PR TITLE
Fix runtime fallback for calculating episode progress

### DIFF
--- a/resources/lib/syncEpisodes.py
+++ b/resources/lib/syncEpisodes.py
@@ -496,7 +496,7 @@ class SyncEpisodes:
                         # Trakt to avoid later using 0 in runtime * progress_pct.
                         if not episode['runtime']:
                             episode['runtime'] = self.sync.traktapi.getEpisodeSummary(
-                                show['ids']['trakt'], season['number'], episode['number'], extended='full').runtime
+                                show['ids']['trakt'], season['number'], episode['number'], extended='full').runtime * 60
                         episodes.append(
                             {'episodeid': episode['ids']['episodeid'], 'progress': episode['progress'], 'runtime': episode['runtime']})
 

--- a/resources/lib/syncMovies.py
+++ b/resources/lib/syncMovies.py
@@ -329,6 +329,12 @@ class SyncMovies():
 
             self.sync.UpdateProgress(fromPercent, line1='', line2=kodiUtilities.getString(
                 32126) % len(kodiMoviesToUpdate))
+            # If library item doesn't have a runtime set get it from
+            # Trakt to avoid later using 0 in runtime * progress_pct.
+            for movie in kodiMoviesToUpdate:
+                if not movie['runtime']:
+                    movie['runtime'] = self.sync.traktapi.getMovieSummary(
+                        movie['ids']['trakt'], extended='full').runtime * 60
             # need to calculate the progress in int from progress in percent from Trakt
             # split movie list into chunks of 50
             chunksize = 50

--- a/resources/lib/traktapi.py
+++ b/resources/lib/traktapi.py
@@ -320,9 +320,9 @@ class traktAPI(object):
 
         return progressEpisodes
 
-    def getMovieSummary(self, movieId):
+    def getMovieSummary(self, movieId, extended=None):
         with Trakt.configuration.http(retry=True):
-            return Trakt['movies'].get(movieId)
+            return Trakt['movies'].get(movieId, extended=extended)
 
     def getShowSummary(self, showId):
         with Trakt.configuration.http(retry=True):


### PR DESCRIPTION
- Kodi handles episode runtimes in seconds
- This addon fetches episode runtimes from Trakt as fallback to avoid multiplying the progress percentage with 0
- Trakt stores and returns runtimes in minutes and this addon did not account for that which led to issues, see #571 
- This fix converts the Trakt runtime to seconds by multiplying it with 60, which resolves the issue