### PR TITLE
Fix title/year fallback ignoring year

### DIFF
--- a/resources/lib/utilities.py
+++ b/resources/lib/utilities.py
@@ -128,7 +128,7 @@ def findMediaObject(mediaObjectToMatch, listToSearch, matchByTitleAndYear):
                 year=mediaObjectToMatch["year"],
             )
         # match only by title, as some items don't have a year on trakt
-        if result is None and "title" in mediaObjectToMatch:
+        elif result is None and "title" in mediaObjectToMatch:
             result = __findInList(listToSearch, title=mediaObjectToMatch["title"])
 
     return result
@@ -521,11 +521,11 @@ def compareEpisodes(
                                             in season_col2[season][ep]["ids"]
                                         ):
                                             if "ids" in eps:
-                                                eps[ep]["ids"][
-                                                    "episodeid"
-                                                ] = season_col2[season][ep]["ids"][
-                                                    "episodeid"
-                                                ]
+                                                eps[ep]["ids"]["episodeid"] = (
+                                                    season_col2[season][ep]["ids"][
+                                                        "episodeid"
+                                                    ]
+                                                )
                                             else:
                                                 eps[ep]["ids"] = {
                                                     "episodeid": season_col2[season][
@@ -558,11 +558,11 @@ def compareEpisodes(
                                             in collectedSeasons[season][ep]["ids"]
                                         ):
                                             if "ids" in eps:
-                                                eps[ep]["ids"][
-                                                    "episodeid"
-                                                ] = collectedSeasons[season][ep]["ids"][
-                                                    "episodeid"
-                                                ]
+                                                eps[ep]["ids"]["episodeid"] = (
+                                                    collectedSeasons[season][ep]["ids"][
+                                                        "episodeid"
+                                                    ]
+                                                )
                                             else:
                                                 eps[ep]["ids"] = {
                                                     "episodeid": collectedSeasons[

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -511,11 +511,11 @@ def test_findMediaObject_not_matchByTitleAndYear_add_collection_same_year_title_
     assert utilities.findMediaObject(data1, data2, False) is None
 
 
-def test_findMediaObject_match_by_title_should_match():
+def test_findMediaObject_matchByTitleAndYear_should_not_match():
     data1 = load_params_from_json("tests/fixtures/movies_local_blind.json")
     data2 = load_params_from_json("tests/fixtures/movies_remote_blind_no_match.json")
 
-    assert utilities.findMediaObject(data1, data2, True) == data2[0]
+    assert utilities.findMediaObject(data1, data2, True) is None
 
 
 def test_findMediaObject_matchByTitleAndYear_should_match():


### PR DESCRIPTION
This fixes #620 

**Example:**
You have Gossip Girl (2007) in your Trakt history and Gossip Girl (2021) in your library. You have "Fallback to title and year if necessary" activated and you want to sync your watched episodes to your Kodi library.

**Current behavior**
- findMediaObject is called with Gossip Girl (2007) as mediaObjectToMatch
- It is not matched with either the IMDB ID, TMDB ID or TVDB Id, so the result is still None
- Matching the show by title and year still gives no result, so the result is still none
- Matching the show only by title returns Gossip Girl (2021) from the Kodi library as a match, which is wrong

**Behavior after the fix**
- The mediaObjectToMatch has a title and year, so the if clause to look for a match by title and year is true
- There is no match in the Kodi library, so the result is still None
- The library listToSearch is not searched for a match only by title anymore, so the method correctly returns no match

I tested it on my Kodi instance for the ratings sync and the "Mark episodes from Trakt history as watched" sync and it should also work for movies as compareMovies uses the same findMediaObject method