### PR TITLE
Service: Add support for script.trakt.exclude listitem property

### DIFF
--- a/resources/lib/service.py
+++ b/resources/lib/service.py
@@ -510,7 +510,10 @@ class traktPlayer(xbmc.Player):
                 {
                     "jsonrpc": "2.0",
                     "method": "Player.GetItem",
-                    "params": {"playerid": playerId},
+                    "params": {
+                        "playerid": playerId,
+                        "properties": ["customproperties"],
+                    },
                     "id": 1,
                 }
             )
@@ -523,6 +526,14 @@ class traktPlayer(xbmc.Player):
                 except:  # noqa: E722
                     logger.debug(
                         "[traktPlayer] onAVStarted() - Exception trying to get playing filename, player suddenly stopped."
+                    )
+                    return
+
+                custom_proprties = result["item"].get("customproperties")
+                if custom_proprties and "script.trakt.exclude" in custom_proprties:
+                    logger.debug(
+                        "[traktPlayer] onAVStarted() - '%s' has exclusion property, ignoring."
+                        % _filename
                     )
                     return
 


### PR DESCRIPTION
This allows other plugins etc to set a "script.trakt.exclude" listitem property
Trakt service then simply ignores if this is found.

It was suggested to use the window property on https://github.com/trakt/script.trakt/issues/651
However, that has some issues.
The main issue is that you can only set it when your sure your content is going to play.
Otherwise, playback stopped wont be called in trakt and that property is not then cleared.
Resulting in the next content played is ignored (not good).

List item property has no such issue.

The API customproperties was added here: https://github.com/xbmc/xbmc/pull/18106
Its in Kodi 19 and up.
Only found out about this tonight after a good google - Very handy!!

Looks like trakt addon is Kodi 20 and up now only so the code should be able to rely on it being present

Example usage
```
li = xbmcgui.ListItem()
li.setProperty("script.trakt.exclude", "1") #value doesnt matter
li.setPath("trailer_url")
```